### PR TITLE
v1.0.0 - 워크스페이스 메타 파일 ignore 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Byte-compiled / optimized
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+*.egg-info/
+build/
+dist/
+
+# Environments
+.env
+.env.*
+.venv/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Local workspace meta
+.workspace/
+WORKSPACE.md


### PR DESCRIPTION
## 변경 내용
- `.gitignore` 에 워크스페이스 메타 파일 보호 패턴 추가 (`.workspace/`, `WORKSPACE.md`)
- 언어별 표준 ignore 패턴 (.env, IDE, OS, 빌드 산출물) 함께 추가

## 테스트 방법
- `git status` 에서 `.workspace/`, `WORKSPACE.md` 가 추적 대상에 안 나오는지 확인

Closes #1