### PR TITLE
v1.2.0 - 안양 보행망 그래프 구축 대응 (무장애 태그 보존·osmnx 2.x·DEM 종단경사)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ WORKSPACE.md
 # 네트워크 그래프 · POI 데이터 · 결과물 (대용량/실데이터 — 커밋 금지)
 data/*.gpickle
 data/dem/
+data/terrain/
 data/poi/*.json
 results/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.1.0 |
+| 02-IITP-DABT-Route | v1.2.0 |
 
 ## 구조
 
@@ -42,10 +42,15 @@ pip install -r requirements.txt          # 서비스 구동
 pip install -r requirements-build.txt    # 그래프 구축 시에만
 
 cp .env.example .env                     # 값 채우기 (레포에 커밋 금지)
+# 안양 보행망 + 공개DEM 으로 그래프 구축
 python scripts/build_network.py --source osm \
     --place "Anyang-si, Gyeonggi-do, South Korea" \
-    --dem data/dem/anyang_5m.img \
-    --out data/network_anyang.gpickle --version anyang-osm-2026Q3
+    --dem data/dem/anyang_37612_90m.img \
+    --out data/network_anyang.gpickle --version anyang-osm-dem90-2026Q3
+
+# 품질 확인 (경사 커버리지가 0 이면 경사 회피가 동작하지 않는다)
+python scripts/inspect_network.py --network data/network_anyang.gpickle \
+    --route 37.4025,126.9227,37.3856,126.9256
 
 uvicorn route_service.api.main:app --host 0.0.0.0 --port 18100
 ```
@@ -122,9 +127,28 @@ curl -X POST localhost:18100/route/plan -H "Content-Type: application/json" -d '
 
 | 구분 | 현재 | 비고 |
 |---|---|---|
-| 보행 네트워크 | **OSM 안양 보행망** (선구축) | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
-| 경사(DEM) | 국토정보플랫폼 안양 5m DEM(.img) | 미지정 시 경사 0 (경사 회피 미동작) — `/meta/network` 의 `slope_coverage` 로 확인 |
+| 보행 네트워크 | **OSM 안양 보행망** — 노드 6,750 / 링크 9,712 | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
+| 경사 | **국토지리정보원 공개DEM 90m**(도엽 37612) — 커버리지 99.5% | 5m DEM 확보 시 `--dem` 만 교체. DEM 이 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
 | 무장애 관광지·역·정류장 | 01-IITP-DABT-Database (`POI_BACKEND=db`) | 파이프라인 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
+
+### 안양 그래프 실측 (v1.2.0)
+
+| 링크 타입 | 비율 | | 경사 | |
+|---|---|---|---|---|
+| 도로·이면도로 | 71.1% | | 4° 초과(수동 휠체어 통행 불가) | **1,087개 (11.2%)** |
+| 보도 | 20.9% | | 최대 | 28.0° |
+| 횡단보도 | 4.3% | | 경사 커버리지 | 99.5% |
+| 계단·육교·지하보도 | 1.4% | | 보도폭 커버리지 | 0.1% (OSM 한계) |
+
+경로 비교 (안양역 → 안양예술공원)
+
+| 프로필 | 거리 | 최대 경사 | 계단 |
+|---|---|---|---|
+| 수동 휠체어 | 2,390m | **3.21°** | 0 |
+| 일반 보행 | 2,385m | 4.78° | 0 |
+
++5m 우회로 급경사 구간을 회피한다. 보도폭·턱낮춤은 OSM 태그 커버리지가 낮아
+현재는 판정에 거의 기여하지 못한다 — 융기원 원본 데이터에서 보강해야 하는 항목이다.
 
 데이터 품질은 `/meta/network` 와 경로 응답의 `data_quality` 로 항상 노출한다. 계단·경사 속성이
 없는 네트워크에서는 회피 판정이 성립하지 않으므로 반드시 확인할 것.

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,6 +3,8 @@ osmnx>=1.9
 pandas>=2.0
 openpyxl>=3.1
 numpy>=1.24
-# DEM 경사 부여 시
-xdem>=0.1
+# DEM 경사 부여 시 (국토지리정보원 공개DEM .img 직접 읽기)
+rasterio>=1.3
 pyproj>=3.6
+# 지형 타일(--elevation terrain) 사용 시
+pillow>=10.0

--- a/route_service/engine/dem.py
+++ b/route_service/engine/dem.py
@@ -1,64 +1,137 @@
 # -*- coding: utf-8 -*-
-"""DEM(.img) 기반 링크 경사 부여.
+"""DEM 기반 링크 종단경사 산출.
 
-기존 build_network.py 의 경사 산출 로직을 재사용 가능한 함수로 분리했다.
-xdem/pyproj 는 선택 의존성이며, DEM 이 없으면 경사는 0 으로 두고
-meta.slope_coverage 로 품질을 고지한다(경로는 여전히 생성된다).
+국토지리정보원 공개DEM(.img, EPSG:5179) 을 그대로 읽는다.
+
+설계 결정 — '경사도 래스터'가 아니라 '링크 종단경사(grade)'를 쓴다:
+  기존 build_network.py 는 DEM 에서 지형 경사도(terrain slope)를 뽑아 링크에 붙였다.
+  그러나 휠체어 통행 가부를 좌우하는 것은 주변 지형이 얼마나 가파른가가 아니라
+  **그 길을 따라 실제로 얼마나 오르내리는가**이다. 경사도 래스터를 쓰면 옆이 절벽인
+  평지 보도가 급경사로 오판된다. 그래서 링크 양 끝점의 표고차 / 링크 연장으로 계산한다.
+
+격자가 성길수록(90m) 짧은 링크의 표고차가 0 으로 뭉개지므로 **이중선형 보간**으로 표고를 읽는다.
 """
 from __future__ import annotations
 
 import math
 
 
-def apply_slope_from_dem(G, dem_path: str, sample_step_m: float = 5.0, bbox=None) -> dict:
-    """그래프의 각 링크에 평균 경사(도)를 채운다. 반환: 통계."""
-    import numpy as np
-    import xdem
-    from pyproj import Transformer
+class DemSampler:
+    """DEM 래스터에서 위경도로 표고(m)를 조회한다(이중선형 보간)."""
 
-    dem = xdem.DEM(dem_path)
-    to_dem = Transformer.from_crs("EPSG:4326", dem.crs, always_xy=True)
+    def __init__(self, dem_path: str):
+        import rasterio
+        from pyproj import Transformer
 
-    if bbox:
-        min_lat, min_lng, max_lat, max_lng = bbox
-        x_min, y_min = to_dem.transform(min_lng, min_lat)
-        x_max, y_max = to_dem.transform(max_lng, max_lat)
-        dem = dem.crop([x_min, y_min, x_max, y_max])
+        self.src = rasterio.open(dem_path)
+        self.nodata = self.src.nodata
+        self.to_dem = Transformer.from_crs("EPSG:4326", self.src.crs, always_xy=True)
+        self.band = self.src.read(1)
+        self.h, self.w = self.band.shape
 
-    slope_raster = xdem.terrain.slope(dem)
-    arr = slope_raster.data.filled(np.nan)
-    transform = dem.transform
+    @property
+    def meta(self) -> dict:
+        b = self.src.bounds
+        return {
+            "crs": str(self.src.crs),
+            "res_m": float(self.src.res[0]),
+            "size": [self.src.width, self.src.height],
+            "bounds": [b.left, b.bottom, b.right, b.top],
+        }
 
-    def slope_at(lat, lon):
-        x, y = to_dem.transform(lon, lat)
-        col, row = ~transform * (x, y)
+    def _valid(self, v) -> bool:
+        if v is None:
+            return False
+        if self.nodata is not None and abs(float(v) - float(self.nodata)) < 1e-6:
+            return False
+        return not math.isnan(float(v))
+
+    def elevation(self, lat: float, lon: float):
+        x, y = self.to_dem.transform(lon, lat)
+        col, row = ~self.src.transform * (x, y)
+        c0, r0 = int(math.floor(col - 0.5)), int(math.floor(row - 0.5))
+        fx, fy = (col - 0.5) - c0, (row - 0.5) - r0
+
+        acc, wsum = 0.0, 0.0
+        for dr in (0, 1):
+            for dc in (0, 1):
+                rr, cc = r0 + dr, c0 + dc
+                if not (0 <= rr < self.h and 0 <= cc < self.w):
+                    continue
+                v = self.band[rr, cc]
+                if not self._valid(v):
+                    continue
+                wgt = (fx if dc else 1 - fx) * (fy if dr else 1 - fy)
+                if wgt <= 0:
+                    continue
+                acc += float(v) * wgt
+                wsum += wgt
+        if wsum == 0:
+            return None
+        return acc / wsum
+
+    def close(self):
         try:
-            v = arr[int(row), int(col)]
-        except IndexError:
-            return float("nan")
-        return float(v)
+            self.src.close()
+        except Exception:
+            pass
 
-    from .graph import edge_coords
+
+def apply_slope_from_dem(G, dem_path: str, **_ignored) -> dict:
+    """그래프의 각 링크에 종단경사(도)를 채운다. 반환: 통계."""
     from .geo import haversine_m
 
+    sampler = DemSampler(dem_path)
+    cache = {}
+
+    def elev_of(node):
+        if node not in cache:
+            d = G.nodes[node]
+            cache[node] = sampler.elevation(d["lat"], d["lon"])
+        return cache[node]
+
     filled = 0
+    missing = 0
+    steepest = 0.0
+    hist = {"0-2": 0, "2-4": 0, "4-6": 0, "6-8": 0, "8+": 0}
+
     for u, v, data in G.edges(data=True):
-        coords = edge_coords(G, u, v)
-        seg_len = float(data.get("length") or 0.0) or haversine_m(
-            coords[0][0], coords[0][1], coords[-1][0], coords[-1][1]
+        e1, e2 = elev_of(u), elev_of(v)
+        if e1 is None or e2 is None:
+            missing += 1
+            continue
+        length = float(data.get("length") or 0.0) or haversine_m(
+            G.nodes[u]["lat"], G.nodes[u]["lon"], G.nodes[v]["lat"], G.nodes[v]["lon"]
         )
-        n = max(int(seg_len // sample_step_m), 1)
-        samples = []
-        for i in range(n + 1):
-            t = i / n
-            lat = coords[0][0] + (coords[-1][0] - coords[0][0]) * t
-            lon = coords[0][1] + (coords[-1][1] - coords[0][1]) * t
-            s = slope_at(lat, lon)
-            if not math.isnan(s):
-                samples.append(s)
-        if samples:
-            data["slope"] = float(sum(samples) / len(samples))
-            filled += 1
+        if length < 1.0:
+            missing += 1
+            continue
+
+        deg = math.degrees(math.atan(abs(e2 - e1) / length))
+        data["slope"] = round(deg, 3)
+        data["elev_start"] = round(e1, 1)
+        data["elev_end"] = round(e2, 1)
+        filled += 1
+        steepest = max(steepest, deg)
+        if deg < 2:
+            hist["0-2"] += 1
+        elif deg < 4:
+            hist["2-4"] += 1
+        elif deg < 6:
+            hist["4-6"] += 1
+        elif deg < 8:
+            hist["6-8"] += 1
+        else:
+            hist["8+"] += 1
+
+    sampler.close()
     total = G.number_of_edges()
-    return {"edges": total, "slope_filled": filled,
-            "coverage": round(filled / total, 4) if total else 0.0}
+    return {
+        "edges": total,
+        "slope_filled": filled,
+        "missing": missing,
+        "coverage": round(filled / total, 4) if total else 0.0,
+        "max_slope_deg": round(steepest, 2),
+        "slope_hist_deg": hist,
+        "dem": sampler.meta,
+    }

--- a/route_service/engine/elevation.py
+++ b/route_service/engine/elevation.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""지형 타일 기반 링크 종단경사 산출.
+
+국토정보플랫폼 5m DEM(.img)이 확보되기 전까지 쓰는 경로다(dem.py 는 그대로 유지).
+공개 지형 타일(Terrarium PNG, 인증 불필요)에서 표고를 읽어 **링크의 종단경사**를 계산한다.
+
+DEM 래스터의 '지형 경사도'가 아니라 링크를 따라가는 실제 오르내림(grade)을 쓰는 이유:
+휠체어 통행 가부를 좌우하는 것은 주변 지형의 급함이 아니라 그 길을 실제로 얼마나
+올라가야 하는가이기 때문이다. 경사도 래스터는 옆 절벽 때문에 평지 보도를 급경사로
+오판할 수 있다.
+
+표고 디코딩: elevation(m) = (R * 256 + G + B / 256) - 32768
+"""
+from __future__ import annotations
+
+import math
+import os
+
+TILE_URL = os.environ.get(
+    "TERRAIN_TILE_URL",
+    "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png",
+)
+TILE_SIZE = 256
+
+
+def _deg2tile(lat: float, lon: float, z: int):
+    """위경도 -> 타일 좌표(소수점 포함)."""
+    lat_r = math.radians(lat)
+    n = 2.0 ** z
+    x = (lon + 180.0) / 360.0 * n
+    y = (1.0 - math.log(math.tan(lat_r) + 1.0 / math.cos(lat_r)) / math.pi) / 2.0 * n
+    return x, y
+
+
+class TerrainSampler:
+    """타일을 한 번만 받아 캐시하고, 위경도로 표고를 조회한다."""
+
+    def __init__(self, zoom: int = 13, cache_dir: str = "data/terrain"):
+        self.zoom = zoom
+        self.cache_dir = cache_dir
+        self._tiles = {}
+        os.makedirs(cache_dir, exist_ok=True)
+
+    def _tile_array(self, tx: int, ty: int):
+        key = (tx, ty)
+        if key in self._tiles:
+            return self._tiles[key]
+
+        import numpy as np
+        from PIL import Image
+
+        path = os.path.join(self.cache_dir, "%d_%d_%d.png" % (self.zoom, tx, ty))
+        if not os.path.exists(path):
+            import urllib.request
+
+            url = TILE_URL.format(z=self.zoom, x=tx, y=ty)
+            req = urllib.request.Request(url, headers={"User-Agent": "iitp-dabt-route/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as r, open(path, "wb") as f:
+                f.write(r.read())
+
+        img = Image.open(path).convert("RGB")
+        a = np.asarray(img, dtype="float64")
+        elev = (a[:, :, 0] * 256.0 + a[:, :, 1] + a[:, :, 2] / 256.0) - 32768.0
+        self._tiles[key] = elev
+        return elev
+
+    def elevation(self, lat: float, lon: float) -> float:
+        x, y = _deg2tile(lat, lon, self.zoom)
+        tx, ty = int(math.floor(x)), int(math.floor(y))
+        arr = self._tile_array(tx, ty)
+        px = min(TILE_SIZE - 1, max(0, int((x - tx) * TILE_SIZE)))
+        py = min(TILE_SIZE - 1, max(0, int((y - ty) * TILE_SIZE)))
+        return float(arr[py, px])
+
+
+def apply_slope_from_terrain(G, zoom: int = 13, cache_dir: str = "data/terrain") -> dict:
+    """그래프의 각 링크에 종단경사(도)를 채운다. 반환: 통계."""
+    from .geo import haversine_m
+
+    sampler = TerrainSampler(zoom=zoom, cache_dir=cache_dir)
+    elev_cache = {}
+
+    def elev_of(node):
+        if node not in elev_cache:
+            d = G.nodes[node]
+            elev_cache[node] = sampler.elevation(d["lat"], d["lon"])
+        return elev_cache[node]
+
+    filled = 0
+    steepest = 0.0
+    for u, v, data in G.edges(data=True):
+        try:
+            e1, e2 = elev_of(u), elev_of(v)
+        except Exception:
+            continue
+        length = float(data.get("length") or 0.0) or haversine_m(
+            G.nodes[u]["lat"], G.nodes[u]["lon"], G.nodes[v]["lat"], G.nodes[v]["lon"]
+        )
+        if length < 1.0:
+            continue
+        grade = abs(e2 - e1) / length            # 종단경사(비율)
+        deg = math.degrees(math.atan(grade))
+        data["slope"] = round(deg, 3)
+        data["elev_start"] = round(e1, 1)
+        data["elev_end"] = round(e2, 1)
+        filled += 1
+        steepest = max(steepest, deg)
+
+    total = G.number_of_edges()
+    return {
+        "edges": total,
+        "slope_filled": filled,
+        "coverage": round(filled / total, 4) if total else 0.0,
+        "max_slope_deg": round(steepest, 2),
+        "source": "terrain-tiles(z%d)" % zoom,
+    }

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -61,7 +61,7 @@ def _astar(G, start, goal, profile, max_slope_deg, penalized_edges=None):
     return nx.astar_path(G, start, goal, heuristic=heuristic, weight=weight)
 
 
-def _summarize(G, path, profile) -> dict:
+def _summarize(G, path, profile, slope_coverage: float = 1.0) -> dict:
     dist = 0.0
     slopes = []
     counts = {"steps": 0, "crossing": 0, "elevator": 0, "ramp": 0}
@@ -89,6 +89,12 @@ def _summarize(G, path, profile) -> dict:
     slope_score = max(0.0, 1.0 - (max_slope / max(profile.max_slope_deg, 0.1)))
     penalty = 0.3 * counts["steps"] + 0.05 * len(set(warnings))
     score = max(0.0, min(1.0, 0.6 * slope_score + 0.4 - penalty))
+
+    # 경사 데이터가 없는 네트워크에서 "경사 0 = 만점"은 거짓 안심을 준다.
+    # 점수를 깎고 사실을 경고로 알린다.
+    if slope_coverage < 0.5:
+        warnings.append("경사 데이터가 없어 경사 회피가 적용되지 않았습니다")
+        score = min(score, 0.6)
 
     return {
         "total_distance_m": round(dist),
@@ -167,12 +173,13 @@ def plan(store, start_node, goal_node, profile: Profile, alternatives: int = 1,
             break
         routes.append(alt)
 
+    coverage = float(store.meta.get("slope_coverage", 1.0) or 0.0)
     out = []
     for path in routes:
         out.append(
             {
                 "path": path,
-                "summary": _summarize(G, path, profile),
+                "summary": _summarize(G, path, profile, coverage),
                 "geometry": _geometry(G, path),
             }
         )

--- a/route_service/engine/sources/osm.py
+++ b/route_service/engine/sources/osm.py
@@ -80,11 +80,24 @@ def incline_to_deg(tags: dict):
         return None
 
 
+# osmnx 는 기본적으로 소수의 way 태그만 보존한다(useful_tags_way).
+# 그 기본값에는 footway·incline·kerb·wheelchair·surface 가 없어서,
+# 그대로 쓰면 횡단보도·경사·턱낮춤·휠체어 통행 가부를 전부 잃는다 — 회피 판정이 무력화된다.
+WALK_TAGS = [
+    "bridge", "tunnel", "oneway", "ref", "name", "highway", "service", "access", "area",
+    "junction", "width", "est_width",
+    # 무장애 판정에 필수
+    "footway", "incline", "kerb", "wheelchair", "surface", "conveying",
+    "tactile_paving", "ramp", "handrail", "step_count", "crossing",
+]
+
+
 def build_from_osm(place: str = "Anyang-si, Gyeonggi-do, South Korea",
                    bbox=None, network_type: str = "walk") -> nx.Graph:
     """osmnx 로 보행망을 받아 표준 Graph 를 만든다.
 
     place 또는 bbox(min_lat, min_lng, max_lat, max_lng) 중 하나를 준다.
+    osmnx 1.x / 2.x 양쪽의 graph_from_bbox 시그니처를 모두 처리한다.
     """
     try:
         import osmnx as ox
@@ -93,10 +106,23 @@ def build_from_osm(place: str = "Anyang-si, Gyeonggi-do, South Korea",
             "osmnx 가 필요합니다: pip install osmnx  (그래프 구축 시에만 필요)"
         ) from e
 
+    try:
+        ox.settings.useful_tags_way = WALK_TAGS
+    except AttributeError:  # osmnx 1.x 이전
+        ox.utils.config(useful_tags_way=WALK_TAGS)
+
     if bbox:
         min_lat, min_lng, max_lat, max_lng = bbox
-        Gx = ox.graph_from_bbox(max_lat, min_lat, max_lng, min_lng, network_type=network_type,
-                                simplify=True, retain_all=False)
+        try:
+            # osmnx >= 2.0 : bbox=(left, bottom, right, top) = (서, 남, 동, 북)
+            Gx = ox.graph_from_bbox(
+                bbox=(min_lng, min_lat, max_lng, max_lat),
+                network_type=network_type, simplify=True, retain_all=False,
+            )
+        except TypeError:
+            # osmnx 1.x : (north, south, east, west) 위치 인자
+            Gx = ox.graph_from_bbox(max_lat, min_lat, max_lng, min_lng,
+                                    network_type=network_type, simplify=True, retain_all=False)
     else:
         Gx = ox.graph_from_place(place, network_type=network_type, simplify=True, retain_all=False)
 

--- a/route_service/engine/steps.py
+++ b/route_service/engine/steps.py
@@ -65,9 +65,19 @@ def _edge_warnings(data: dict, profile: Profile) -> list:
     return out
 
 
+def _josa(word: str, with_batchim: str, without_batchim: str) -> str:
+    """받침 유무에 따른 조사 선택 — 음성 안내 문장이 어색해지지 않도록."""
+    if not word:
+        return without_batchim
+    ch = word[-1]
+    if not ("가" <= ch <= "힣"):
+        return without_batchim
+    return with_batchim if (ord(ch) - 0xAC00) % 28 else without_batchim
+
+
 def _sentence(maneuver: str, distance_m: float, link_name, data: dict, warnings: list) -> str:
     dist = int(round(distance_m))
-    where = ("%s을 따라 " % link_name) if link_name else ""
+    where = ("%s%s 따라 " % (link_name, _josa(link_name, "을", "를"))) if link_name else ""
     lt = data["link_type"]
 
     if maneuver == "depart":

--- a/scripts/build_network.py
+++ b/scripts/build_network.py
@@ -27,6 +27,13 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Windows 기본 콘솔 인코딩(cp949)에서 한글·기호 출력이 깨지지 않도록
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:  # pragma: no cover
+    pass
+
 from route_service.engine.graph import normalize_graph  # noqa: E402
 from route_service.engine.sources import build_from_osm, build_from_tabular  # noqa: E402
 
@@ -38,7 +45,10 @@ def main():
     ap.add_argument("--bbox", help="min_lat,min_lng,max_lat,max_lng")
     ap.add_argument("--node", help="tabular: node 파일(xlsx/csv)")
     ap.add_argument("--link", help="tabular: link 파일(xlsx/csv)")
-    ap.add_argument("--dem", help="DEM(.img) 경로 — 없으면 경사 0 으로 두고 진행")
+    ap.add_argument("--dem", help="DEM(.img) 경로 (국토정보플랫폼 5m 등)")
+    ap.add_argument("--elevation", choices=("none", "terrain"), default="none",
+                    help="DEM 이 없을 때 경사 산출 방식. terrain=공개 지형 타일(인증 불필요, 약 30m급)")
+    ap.add_argument("--tile-zoom", type=int, default=13, help="지형 타일 zoom (기본 13)")
     ap.add_argument("--out", default="data/network.gpickle")
     ap.add_argument("--version", default="unknown")
     args = ap.parse_args()
@@ -65,8 +75,14 @@ def main():
 
         stat = apply_slope_from_dem(G, args.dem, bbox=bbox)
         print("[build] 경사 적용: %s" % json.dumps(stat, ensure_ascii=False))
+    elif args.elevation == "terrain":
+        print("[build] 지형 타일로 종단경사 산출 (zoom=%d)" % args.tile_zoom)
+        from route_service.engine.elevation import apply_slope_from_terrain
+
+        stat = apply_slope_from_terrain(G, zoom=args.tile_zoom)
+        print("[build] 경사 적용: %s" % json.dumps(stat, ensure_ascii=False))
     else:
-        print("[build] DEM 미지정 — 경사 0 (경사 회피가 동작하지 않습니다)")
+        print("[build] 경사 데이터 없음 — 경사 회피가 동작하지 않습니다 (--dem 또는 --elevation terrain 사용)")
 
     os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
     with open(args.out, "wb") as f:

--- a/scripts/inspect_network.py
+++ b/scripts/inspect_network.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""네트워크 품질 리포트 + 샘플 경로 검증 (CLI).
+
+그래프를 새로 구축하거나 교체한 뒤 이 스크립트로 품질을 확인한다.
+경사 커버리지가 0 이면 경사 회피가 동작하지 않는다는 뜻이므로 반드시 확인할 것.
+
+사용 예)
+  python scripts/inspect_network.py --network data/network_anyang.gpickle \
+      --route 37.4025,126.9227,37.3856,126.9256
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:  # pragma: no cover
+    pass
+
+from route_service.engine.graph import NetworkStore  # noqa: E402
+from route_service.engine.planner import NoRouteError, plan  # noqa: E402
+from route_service.engine.profiles import get_profile  # noqa: E402
+from route_service.engine.snap import snap  # noqa: E402
+from route_service.engine.steps import build_steps  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description="네트워크 품질 리포트")
+    ap.add_argument("--network", default="data/network_anyang.gpickle")
+    ap.add_argument("--route", action="append", default=[],
+                    help="olat,olng,dlat,dlng — 프로필별 비교 경로(여러 번 지정 가능)")
+    ap.add_argument("--steps", type=int, default=5, help="출력할 턴바이턴 스텝 수")
+    args = ap.parse_args()
+
+    store = NetworkStore()
+    m = store.load(args.network)
+
+    print("== 네트워크 ==")
+    print("  노드 %d / 링크 %d" % (m["node_cnt"], m["edge_cnt"]))
+    print("  경사 커버리지 %.1f%% / 보도폭 커버리지 %.1f%%"
+          % (m["slope_coverage"] * 100, m["width_coverage"] * 100))
+    if m["slope_coverage"] < 0.5:
+        print("  ⚠ 경사 데이터가 없습니다 — 경사 회피가 동작하지 않습니다")
+    b = m["bbox"]
+    print("  범위 lat %.4f~%.4f / lng %.4f~%.4f"
+          % (b["min_lat"], b["max_lat"], b["min_lng"], b["max_lng"]))
+
+    print("== 링크 타입 ==")
+    total = m["edge_cnt"] or 1
+    for t, c in sorted(m["link_type_counts"].items(), key=lambda x: -x[1]):
+        print("  %-10s %6d (%5.1f%%)" % (t, c, c / total * 100))
+
+    G = store.graph
+    steep = [d["slope"] for _u, _v, d in G.edges(data=True) if d["slope"] > 4.0]
+    print("== 경사 ==")
+    print("  4도 초과 링크 %d개 (%.1f%%) — 수동 휠체어 통행 불가 구간"
+          % (len(steep), len(steep) / total * 100))
+
+    for spec in args.route:
+        try:
+            olat, olng, dlat, dlng = [float(x) for x in spec.split(",")]
+        except ValueError:
+            print("경로 형식 오류: %s" % spec)
+            continue
+        print("\n===== 경로 %s =====" % spec)
+        summaries = {}
+        for pid in ("wheelchair_manual", "walk"):
+            p = get_profile(pid)
+            o = snap(store, olat, olng, p)
+            d = snap(store, dlat, dlng, p)
+            try:
+                res = plan(store, o["node_id"], d["node_id"], p)
+            except NoRouteError as e:
+                print("  [%s] 경로 없음: %s" % (p.label, e))
+                continue
+            s = res["routes"][0]["summary"]
+            summaries[pid] = s
+            print("  [%-8s] %5dm / %3d분 / 계단 %d / 최대경사 %5.2f° / 평균 %4.2f° / 접근성 %.2f"
+                  % (p.label, s["total_distance_m"], s["duration_sec"] // 60, s["stairs_cnt"],
+                     s["max_slope_deg"], s["mean_slope_deg"], s["accessibility_score"]))
+            if res["fallback"]["used"]:
+                print("      ↳ %s" % res["fallback"]["reason"])
+            for w in s["warnings"]:
+                print("      ↳ 경고: %s" % w)
+            if pid == "wheelchair_manual" and args.steps:
+                steps = build_steps(G, res["routes"][0]["path"], p)
+                print("      턴바이턴 %d스텝:" % len(steps))
+                for st in steps[:args.steps]:
+                    print("        %2d %s" % (st["idx"], st["instruction"]))
+
+        if "wheelchair_manual" in summaries and "walk" in summaries:
+            wc, wk = summaries["wheelchair_manual"], summaries["walk"]
+            print("  → 휠체어 우회 %+dm / 최대경사 %.2f° → %.2f° / 계단 %d → %d"
+                  % (wc["total_distance_m"] - wk["total_distance_m"],
+                     wk["max_slope_deg"], wc["max_slope_deg"],
+                     wk["stairs_cnt"], wc["stairs_cnt"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/planning.py
+++ b/scripts/planning.py
@@ -18,6 +18,13 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Windows 기본 콘솔 인코딩(cp949)에서 한글·기호 출력이 깨지지 않도록
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:  # pragma: no cover
+    pass
+
 from route_service.engine.graph import NetworkStore  # noqa: E402
 from route_service.engine.planner import NoRouteError, plan  # noqa: E402
 from route_service.engine.profiles import get_profile  # noqa: E402

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -55,3 +55,16 @@ def test_off_route_distance(store):
     geom = plan(store, "N1", "N3", get_profile("wheelchair_manual"))["routes"][0]["geometry"]
     assert off_route_distance_m(geom, 37.3900, 126.9505) < 20
     assert off_route_distance_m(geom, 37.3850, 126.9505) > 200
+
+
+def test_no_slope_data_does_not_score_perfect(store):
+    """경사 데이터가 없는 네트워크에서 '경사 0 = 만점'은 거짓 안심을 준다."""
+    G = store.graph
+    for _u, _v, d in G.edges(data=True):
+        d["slope"] = 0.0
+    store.load_graph_object(G, version="no-slope")
+    assert store.meta["slope_coverage"] == 0.0
+
+    s = plan(store, "N1", "N3", get_profile("wheelchair_manual"))["routes"][0]["summary"]
+    assert s["accessibility_score"] <= 0.6
+    assert any("경사 데이터가 없어" in w for w in s["warnings"])

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -35,3 +35,13 @@ def test_warning_for_steep_segment(store):
     steps = build_steps(store.graph, ["N1", "N4", "N3"], p)
     texts = " ".join(s["instruction"] for s in steps)
     assert "계단" in texts
+
+
+def test_josa_selection_for_road_names(store):
+    """받침 유무에 따라 '을/를'을 골라야 음성 안내가 어색해지지 않는다."""
+    from route_service.engine.steps import _josa
+
+    assert _josa("평촌대로254번길", "을", "를") == "을"   # 받침 있음
+    assert _josa("달안로", "을", "를") == "를"           # 받침 없음
+    assert _josa("경수대로", "을", "를") == "를"
+    assert _josa(None, "을", "를") == "를"


### PR DESCRIPTION
Close #5

## 변경 요약
안양시 보행망을 실제로 구축하면서 드러난 어댑터 결함을 고치고, 공개DEM 으로 경사를 채웠다.

### 1. 무장애 판정 태그 유실 (가장 치명적)
osmnx 의 기본 `useful_tags_way` 에는 `footway`·`incline`·`kerb`·`wheelchair`·`surface` 가 없다. 그대로 쓰면 **횡단보도·경사·턱낮춤·휠체어 통행 가부를 전부 잃어 회피 판정 자체가 무력화된다.** 태그 보존 목록을 명시했다.

### 2. osmnx 2.x 시그니처
`graph_from_bbox` 인자가 `bbox=(west,south,east,north)` 로 변경 — 1.x/2.x 양쪽 처리.

### 3. DEM: 지형 경사도 -> 링크 종단경사
기존 로직은 DEM 에서 지형 경사도(terrain slope)를 뽑아 링크에 붙였다. 그러나 휠체어 통행 가부를 좌우하는 것은 주변 지형의 급함이 아니라 **그 길을 실제로 얼마나 오르내리는가**다. 경사도 래스터를 쓰면 옆이 절벽인 평지 보도가 급경사로 오판된다. 링크 양 끝 표고차 / 연장으로 계산하도록 바꾸고, 90m 격자에서 짧은 링크가 0 으로 뭉개지지 않도록 이중선형 보간을 적용했다. 구현도 xdem -> rasterio 로 교체(.img 직접 읽기, 의존성 경량화).

### 4. 경사 데이터 없을 때 접근성 만점 방지
경사 0 인 그래프에서 접근성 점수 1.0 은 거짓 안심을 준다. 커버리지 50% 미만이면 점수 상한 0.6 + 경고를 노출한다.

### 5. 그 외
- 지형 타일(인증 불필요) 경사 산출 경로 추가 — 고해상도 DEM 확보 전 대안
- 턴바이턴 한국어 조사(을/를) 처리 — "달안로을" -> "달안로를"
- `scripts/inspect_network.py`: 네트워크 품질 리포트 + 프로필별 경로 비교 CLI
- Windows 콘솔(cp949) 출력 인코딩 처리

## 실측 결과 (안양시)

| 항목 | 값 |
|---|---|
| 노드 / 링크 | 6,750 / 9,712 |
| 경사 커버리지 | 99.5% (공개DEM 90m, 도엽 37612) |
| 4° 초과 링크 | **1,087개 (11.2%)** — 수동 휠체어 통행 불가 |
| 계단 / 육교 / 지하보도 | 56 / 43 / 38 |
| 보도폭 커버리지 | 0.1% (OSM 한계 — 융기원 원본에서 보강 필요) |

경로 비교

| 구간 | 수동 휠체어 | 일반 보행 |
|---|---|---|
| 안양역 → 안양예술공원 | 2,390m / **최대경사 3.21°** / 계단 0 | 2,385m / 최대경사 4.78° / 계단 0 |
| 안양시청 → 평촌중앙공원 | 1,132m / **계단 0** | 1,126m / 계단 1 |

+5~6m 우회로 급경사·계단을 회피한다.

## 검증
- pytest 30건 통과 (조사 처리, 경사 데이터 부재 시 점수 상한 테스트 추가)
- compileall 통과
- 실제 안양 그래프로 스냅 -> 경로 -> 턴바이턴 E2E 확인

## 남은 데이터 한계
- **보도폭·턱낮춤**: OSM 태그 커버리지 0.1%/0% — 판정에 거의 기여하지 못한다. 융기원 원본(WIDTH·CURB)에서 보강해야 한다.
- **경사 해상도**: 90m 격자라 골목 단위 급경사는 평활화된다. 국토정보플랫폼 5m DEM 확보 시 `--dem` 만 교체하면 된다.