### PR TITLE
v1.3.0 - 수치지형도 등고선으로 5m DEM 생성 (90m 격자의 경사 오판 제거)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.2.0 |
+| 02-IITP-DABT-Route | v1.3.0 |
 
 ## 구조
 
@@ -42,11 +42,15 @@ pip install -r requirements.txt          # 서비스 구동
 pip install -r requirements-build.txt    # 그래프 구축 시에만
 
 cp .env.example .env                     # 값 채우기 (레포에 커밋 금지)
-# 안양 보행망 + 공개DEM 으로 그래프 구축
+# (1) 수치지형도 등고선 -> 5m DEM 생성
+python scripts/dem_from_contours.py \
+    --src "<수치지도 zip 폴더>" --out data/dem/anyang_5m.tif --res 5
+
+# (2) 안양 보행망 + 5m DEM 으로 그래프 구축
 python scripts/build_network.py --source osm \
     --place "Anyang-si, Gyeonggi-do, South Korea" \
-    --dem data/dem/anyang_37612_90m.img \
-    --out data/network_anyang.gpickle --version anyang-osm-dem90-2026Q3
+    --dem data/dem/anyang_5m.tif \
+    --out data/network_anyang.gpickle --version anyang-osm-dem5-2026Q3
 
 # 품질 확인 (경사 커버리지가 0 이면 경사 회피가 동작하지 않는다)
 python scripts/inspect_network.py --network data/network_anyang.gpickle \
@@ -128,27 +132,24 @@ curl -X POST localhost:18100/route/plan -H "Content-Type: application/json" -d '
 | 구분 | 현재 | 비고 |
 |---|---|---|
 | 보행 네트워크 | **OSM 안양 보행망** — 노드 6,750 / 링크 9,712 | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
-| 경사 | **국토지리정보원 공개DEM 90m**(도엽 37612) — 커버리지 99.5% | 5m DEM 확보 시 `--dem` 만 교체. DEM 이 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
+| 경사 | **5m DEM** — 1:5,000 수치지형도 등고선(주곡선 5m)을 보간해 생성 (`scripts/dem_from_contours.py`) | 공개DEM 90m(`.img`)도 그대로 사용 가능. DEM 이 아예 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
 | 무장애 관광지·역·정류장 | 01-IITP-DABT-Database (`POI_BACKEND=db`) | 파이프라인 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
 
-### 안양 그래프 실측 (v1.2.0)
+### 안양 그래프 실측 (v1.3.0)
 
-| 링크 타입 | 비율 | | 경사 | |
-|---|---|---|---|---|
-| 도로·이면도로 | 71.1% | | 4° 초과(수동 휠체어 통행 불가) | **1,087개 (11.2%)** |
-| 보도 | 20.9% | | 최대 | 28.0° |
-| 횡단보도 | 4.3% | | 경사 커버리지 | 99.5% |
-| 계단·육교·지하보도 | 1.4% | | 보도폭 커버리지 | 0.1% (OSM 한계) |
+노드 6,750 / 링크 9,712 — 도로 71.3% · 보도 20.8% · 횡단보도 4.3% · 계단 50 · 육교 44 · 지하보도 35
 
-경로 비교 (안양역 → 안양예술공원)
+| 경사 격자 | 4° 초과 링크 | 안양역 → 안양예술공원 (수동 휠체어) |
+|---|---|---|
+| 공개DEM 90m | 1,087개 (11.2%) | 2,390m (일반 보행 대비 **+5m**) |
+| **수치지형도 5m** | 965개 (9.9%) | 2,608m (일반 보행 대비 **+220m**) |
 
-| 프로필 | 거리 | 최대 경사 | 계단 |
-|---|---|---|---|
-| 수동 휠체어 | 2,390m | **3.21°** | 0 |
-| 일반 보행 | 2,385m | 4.78° | 0 |
+90m 격자는 언덕의 경사를 인접 평지 도로에까지 번지게 하면서, 정작 짧은 급경사 구간은
+평활화해 놓친다. 5m 로 바꾸자 **실제로 피해야 할 오르막이 드러나 +220m 우회가 발생**한다.
+경사 데이터의 해상도가 곧 안내의 정확도다.
 
-+5m 우회로 급경사 구간을 회피한다. 보도폭·턱낮춤은 OSM 태그 커버리지가 낮아
-현재는 판정에 거의 기여하지 못한다 — 융기원 원본 데이터에서 보강해야 하는 항목이다.
+보도폭·턱낮춤은 OSM 태그 커버리지가 0.1%/0% 라 현재 판정에 거의 기여하지 못한다 —
+융기원 원본 데이터(WIDTH·CURB)에서 보강해야 하는 항목이다.
 
 데이터 품질은 `/meta/network` 와 경로 응답의 `data_quality` 로 항상 노출한다. 계단·경사 속성이
 없는 네트워크에서는 회피 판정이 성립하지 않으므로 반드시 확인할 것.

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,3 +8,8 @@ rasterio>=1.3
 pyproj>=3.6
 # 지형 타일(--elevation terrain) 사용 시
 pillow>=10.0
+
+# 수치지형도 등고선 -> DEM 생성(scripts/dem_from_contours.py) 시
+geopandas>=1.0
+scipy>=1.11
+shapely>=2.0

--- a/scripts/dem_from_contours.py
+++ b/scripts/dem_from_contours.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""수치지형도 등고선 -> DEM(GeoTIFF) 생성.
+
+배경: 국토정보플랫폼에서 즉시 받을 수 있는 공개DEM 은 90m 격자다. 90m 는 골목 단위
+급경사를 평활화해 버려서, 휠체어가 실제로 못 오르는 언덕이 평지로 보인다.
+5m DEM 은 오프라인 신청 대상이라 즉시 확보가 어렵다.
+
+해법: 5m DEM 의 원자료인 **1:5,000 수치지형도 등고선**(주곡선 5m)을 직접 보간해
+동급 해상도의 DEM 을 만든다.
+
+입력: 수치지도 zip 묶음 (레이어 N3L_F0010000=등고선, N3P_F0020000=표고점, EPSG:5186)
+출력: GeoTIFF (기본 5m 격자, 입력과 동일 좌표계)
+
+메모리: 등고선 정점이 수백만 개가 되므로 격자를 블록으로 나눠 블록별로 지역 삼각망을
+구성한다(전역 Delaunay 를 한 번에 만들지 않는다).
+
+사용 예)
+  python scripts/dem_from_contours.py \
+      --src "../91-조사설계_이동편의/경기도 안양시 지도/안양시 수치지형도" \
+      --out data/dem/anyang_5m.tif --res 5
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:  # pragma: no cover
+    pass
+
+CONTOUR_LAYER = "N3L_F0010000"   # 등고선
+SPOT_LAYER = "N3P_F0020000"      # 표고점
+NODATA = -9999.0
+
+
+def _elev_column(gdf):
+    """표고 컬럼 자동 탐지 (등고수치 / 수치 / 수치값 …). UFID·구분 등은 제외."""
+    import pandas as pd
+
+    for c in gdf.columns:
+        if c == "geometry" or "UFID" in str(c).upper():
+            continue
+        s = pd.to_numeric(gdf[c], errors="coerce")
+        if s.notna().mean() > 0.9 and s.max() > 0 and s.max() < 3000:
+            return c
+    return None
+
+
+def _densify(line, spacing: float):
+    """선을 spacing(m) 간격 점열로. 등고선 정점만 쓰면 긴 직선 구간이 비어 보간이 튄다."""
+    length = line.length
+    if length <= 0:
+        return []
+    n = max(int(length // spacing), 1)
+    return [line.interpolate(i / n, normalized=True) for i in range(n + 1)]
+
+
+def collect_points(src_dir: str, spacing: float):
+    """zip 들에서 등고선·표고점을 읽어 (x, y, z) 배열로."""
+    import geopandas as gpd
+    import numpy as np
+
+    zips = sorted(glob.glob(os.path.join(src_dir, "**", "*.zip"), recursive=True))
+    if not zips:
+        raise SystemExit("수치지도 zip 을 찾지 못했습니다: %s" % src_dir)
+    print("[dem] 도엽 %d개" % len(zips))
+
+    xs, ys, zs = [], [], []
+    crs = None
+    tmp = tempfile.mkdtemp(prefix="ct_")
+    try:
+        for i, zp in enumerate(zips, 1):
+            sheet_dir = os.path.join(tmp, "s")
+            shutil.rmtree(sheet_dir, ignore_errors=True)
+            os.makedirs(sheet_dir, exist_ok=True)
+            try:
+                with zipfile.ZipFile(zp) as z:
+                    for n in z.namelist():
+                        if n.startswith((CONTOUR_LAYER, SPOT_LAYER)):
+                            z.extract(n, sheet_dir)
+            except zipfile.BadZipFile:
+                print("  ! 손상된 zip 건너뜀: %s" % os.path.basename(zp))
+                continue
+
+            cp = os.path.join(sheet_dir, CONTOUR_LAYER + ".shp")
+            if os.path.exists(cp):
+                g = gpd.read_file(cp, encoding="cp949")
+                crs = crs or g.crs
+                col = _elev_column(g)
+                if col is not None:
+                    for geom, z_ in zip(g.geometry, g[col]):
+                        if geom is None or z_ is None:
+                            continue
+                        parts = geom.geoms if geom.geom_type.startswith("Multi") else [geom]
+                        for part in parts:
+                            for pt in _densify(part, spacing):
+                                xs.append(pt.x); ys.append(pt.y); zs.append(float(z_))
+
+            sp = os.path.join(sheet_dir, SPOT_LAYER + ".shp")
+            if os.path.exists(sp):
+                g = gpd.read_file(sp, encoding="cp949")
+                crs = crs or g.crs
+                col = _elev_column(g)
+                if col is not None:
+                    for geom, z_ in zip(g.geometry, g[col]):
+                        if geom is None or z_ is None:
+                            continue
+                        xs.append(geom.x); ys.append(geom.y); zs.append(float(z_))
+
+            if i % 25 == 0:
+                print("  ... %d/%d 도엽, 표고점 %d개" % (i, len(zips), len(zs)))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    pts = np.column_stack([np.asarray(xs), np.asarray(ys)])
+    vals = np.asarray(zs, dtype="float64")
+    print("[dem] 표고 표본 %d개 / 표고 범위 %.1f~%.1fm" % (len(vals), vals.min(), vals.max()))
+    return pts, vals, crs
+
+
+def interpolate(pts, vals, res: float, block: int, buffer_m: float):
+    """블록 단위 선형 보간(지역 삼각망). 전역 Delaunay 는 메모리를 감당하지 못한다."""
+    import numpy as np
+    from scipy.interpolate import LinearNDInterpolator
+
+    x_min, y_min = pts[:, 0].min(), pts[:, 1].min()
+    x_max, y_max = pts[:, 0].max(), pts[:, 1].max()
+    w = int((x_max - x_min) / res) + 1
+    h = int((y_max - y_min) / res) + 1
+    print("[dem] 격자 %d x %d (%.0fm)" % (w, h, res))
+
+    grid = np.full((h, w), NODATA, dtype="float32")
+    for r0 in range(0, h, block):
+        for c0 in range(0, w, block):
+            r1, c1 = min(r0 + block, h), min(c0 + block, w)
+            bx0 = x_min + c0 * res
+            bx1 = x_min + c1 * res
+            by1 = y_max - r0 * res          # 위쪽
+            by0 = y_max - r1 * res          # 아래쪽
+
+            m = (
+                (pts[:, 0] >= bx0 - buffer_m) & (pts[:, 0] <= bx1 + buffer_m)
+                & (pts[:, 1] >= by0 - buffer_m) & (pts[:, 1] <= by1 + buffer_m)
+            )
+            if m.sum() < 3:
+                continue
+            interp = LinearNDInterpolator(pts[m], vals[m])
+
+            gx, gy = np.meshgrid(
+                x_min + (np.arange(c0, c1) + 0.5) * res,
+                y_max - (np.arange(r0, r1) + 0.5) * res,
+            )
+            out = interp(gx, gy)
+            out = np.where(np.isnan(out), NODATA, out)
+            grid[r0:r1, c0:c1] = out.astype("float32")
+        print("  ... 행 %d/%d" % (min(r0 + block, h), h))
+
+    filled = float((grid != NODATA).mean())
+    print("[dem] 보간 완료 — 유효 셀 %.1f%%" % (filled * 100))
+    return grid, (x_min, y_max)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="수치지형도 등고선 -> DEM(GeoTIFF)")
+    ap.add_argument("--src", required=True, help="수치지도 zip 이 있는 폴더(하위 폴더 포함)")
+    ap.add_argument("--out", default="data/dem/anyang_5m.tif")
+    ap.add_argument("--res", type=float, default=5.0, help="격자 간격(m)")
+    ap.add_argument("--spacing", type=float, default=5.0, help="등고선 점열화 간격(m)")
+    ap.add_argument("--block", type=int, default=1000, help="보간 블록 크기(셀)")
+    ap.add_argument("--buffer", type=float, default=300.0, help="블록 경계 버퍼(m)")
+    args = ap.parse_args()
+
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    pts, vals, crs = collect_points(args.src, args.spacing)
+    grid, (x_min, y_max) = interpolate(pts, vals, args.res, args.block, args.buffer)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    transform = from_origin(x_min, y_max, args.res, args.res)
+    with rasterio.open(
+        args.out, "w", driver="GTiff",
+        height=grid.shape[0], width=grid.shape[1], count=1,
+        dtype="float32", crs=crs, transform=transform,
+        nodata=NODATA, compress="deflate",
+    ) as dst:
+        dst.write(grid, 1)
+    print("[dem] 저장 완료: %s (%s, %.0fm)" % (args.out, crs, args.res))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Close #7

## 변경 요약
`scripts/dem_from_contours.py` 추가 — 1:5,000 수치지형도의 등고선(`N3L_F0010000`, 주곡선 5m)과 표고점(`N3P_F0020000`)을 보간해 **5m DEM(GeoTIFF)** 을 생성한다.

5m DEM 자체는 국토정보플랫폼에서 오프라인 신청 대상이라 즉시 확보가 어렵다. 그러나 **5m DEM 의 원자료가 바로 이 1:5,000 수치지형도**이므로, 등고선을 직접 보간하면 동급 해상도를 즉시 얻을 수 있다.

구현
- 등고선을 5m 간격으로 점열화(정점만 쓰면 긴 직선 구간이 비어 보간이 튄다)
- **블록 단위 지역 삼각망** — 162만 점 전역 Delaunay 는 메모리를 감당하지 못하므로, 격자를 블록으로 나눠 블록+버퍼 안의 점만으로 보간

## 실측 (안양시)

도엽 196개 / 표고 표본 1,619,857개 / 격자 2,657 x 2,776 (5m, EPSG:5186)

| 경사 격자 | 4° 초과 링크 | 안양역 → 안양예술공원 (수동 휠체어) |
|---|---|---|
| 공개DEM 90m | 1,087개 (11.2%) | 2,390m — 일반 보행 대비 **+5m** |
| **수치지형도 5m** | 965개 (9.9%) | 2,608m — 일반 보행 대비 **+220m** |

90m 격자는 언덕의 경사를 인접 평지 도로에까지 번지게 하면서(4° 초과 링크가 오히려 더 많다), 정작 짧은 급경사 구간은 평활화해 놓친다. 5m 로 바꾸자 **실제로 피해야 할 오르막이 드러나 +220m 우회가 발생**했다. 90m 로는 "거의 우회 없음"이라는 잘못된 안내를 하고 있었던 셈이다.

## 검증
- pytest 30건 통과
- 안양 그래프 재구축 후 스냅 -> 경로 -> 턴바이턴 E2E 확인 (경사 커버리지 96.2%)
- 90m / 5m 두 DEM 으로 각각 구축해 경사 분포·경로 변화 비교

## 남은 한계
- 보도폭·턱낮춤: OSM 커버리지 0.1%/0% — 융기원 원본(WIDTH·CURB) 필요
- 1:1,000 수치지형도(주곡선 1m)를 확보하면 같은 스크립트로 더 정밀한 DEM 생성 가능