### PR TITLE
v1.3.1 - POI db 백엔드 쿼리를 실제 통합DB 스키마에 정합

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.3.0 |
+| 02-IITP-DABT-Route | v1.3.1 |
 
 ## 구조
 
@@ -133,7 +133,8 @@ curl -X POST localhost:18100/route/plan -H "Content-Type: application/json" -d '
 |---|---|---|
 | 보행 네트워크 | **OSM 안양 보행망** — 노드 6,750 / 링크 9,712 | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
 | 경사 | **5m DEM** — 1:5,000 수치지형도 등고선(주곡선 5m)을 보간해 생성 (`scripts/dem_from_contours.py`) | 공개DEM 90m(`.img`)도 그대로 사용 가능. DEM 이 아예 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
-| 무장애 관광지·역·정류장 | 01-IITP-DABT-Database (`POI_BACKEND=db`) | 파이프라인 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
+| 무장애 관광지 | 01-IITP-DABT-Database `poi_tour_bf_facility` (`POI_BACKEND=db`) — **안양 13건 적재 완료** | 08 파이프라인(`--ext-sys TOUR_BF_API`)이 수집. 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
+| 역·정류장 | `poi_station_access_status` 등 — **미적재** | 적재 전까지 `/transit/access-points` 는 빈 결과 |
 
 ### 안양 그래프 실측 (v1.3.0)
 

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -18,20 +18,21 @@ import os
 
 from ..engine.geo import haversine_m
 
+# 01-IITP-DABT-Database `poi_tour_bf_facility` 실제 컬럼 (2026-07-13 실측)
+TOUR_FIELDS = [
+    "toilet_yn", "elevator_yn", "parking_yn", "slope_yn", "subway_yn", "bus_stop_yn",
+    "wheelchair_rent_yn", "tactile_map_yn", "audio_guide_yn", "nursing_room_yn",
+    "accessible_room_yn", "stroller_rent_yn",
+]
+
 # 장애 유형 -> 필요한 편의시설 필드 (10-TripSense 매칭 로직과 동일한 사고)
 DISABILITY_REQUIREMENTS = {
-    "지체장애": ["dis_toilet_yn", "elevator_yn", "dis_parking_yn", "slope_yn", "wheelchair_rent_yn"],
-    "휠체어": ["dis_toilet_yn", "elevator_yn", "slope_yn"],
+    "지체장애": ["toilet_yn", "elevator_yn", "parking_yn", "slope_yn", "wheelchair_rent_yn"],
+    "휠체어": ["toilet_yn", "elevator_yn", "slope_yn"],
     "시각장애": ["tactile_map_yn", "audio_guide_yn"],
     "청각장애": ["audio_guide_yn"],
     "영유아동반": ["nursing_room_yn", "stroller_rent_yn"],
 }
-
-TOUR_FIELDS = [
-    "dis_toilet_yn", "elevator_yn", "dis_parking_yn", "slope_yn", "wheelchair_rent_yn",
-    "tactile_map_yn", "audio_guide_yn", "nursing_room_yn", "accessible_room_yn",
-    "stroller_rent_yn",
-]
 
 
 def _is_y(v) -> bool:
@@ -87,20 +88,29 @@ class PoiStore:
         else:
             rows = self._query(
                 """
-                SELECT fclt_id AS poi_id, fclt_name AS name, addr, latitude, longitude,
-                       dis_toilet_yn, elevator_yn, dis_parking_yn, slope_yn,
-                       wheelchair_rent_yn, tactile_map_yn, audio_guide_yn,
-                       nursing_room_yn, accessible_room_yn, stroller_rent_yn
+                SELECT fclt_id AS poi_id,
+                       fclt_name AS name,
+                       COALESCE(addr_road, addr_jibun) AS addr,
+                       latitude, longitude,
+                       toilet_yn, elevator_yn, parking_yn, slope_yn,
+                       subway_yn, bus_stop_yn, wheelchair_rent_yn, tactile_map_yn,
+                       audio_guide_yn, nursing_room_yn, accessible_room_yn, stroller_rent_yn
                   FROM poi_tour_bf_facility
                  WHERE del_yn = 'N'
-                   AND (:sigungu = '' OR addr LIKE '%' || :sigungu || '%')
+                   AND (:sigungu = ''
+                        OR COALESCE(addr_road, '') LIKE '%%' || :sigungu || '%%'
+                        OR COALESCE(addr_jibun, '') LIKE '%%' || :sigungu || '%%'
+                        OR fclt_name LIKE '%%' || :sigungu || '%%')
                  LIMIT :limit
                 """,
                 {"sigungu": sigungu or "", "limit": limit},
             )
         out = [self._normalize_tour(r) for r in rows]
         if sigungu and self.backend == "file":
-            out = [r for r in out if sigungu in (r.get("addr") or "")]
+            out = [
+                r for r in out
+                if sigungu in (r.get("addr") or "") or sigungu in (r.get("name") or "")
+            ]
         if bbox:
             min_lat, min_lng, max_lat, max_lng = bbox
             out = [
@@ -115,11 +125,12 @@ class PoiStore:
     def _normalize_tour(r: dict) -> dict:
         lat = r.get("latitude", r.get("lat"))
         lng = r.get("longitude", r.get("lng"))
+        addr = r.get("addr") or r.get("addr_road") or r.get("addr_jibun")
         return {
             "poi_id": str(r.get("poi_id") or r.get("fclt_id") or r.get("id") or ""),
             "type": "tour",
             "name": r.get("name") or r.get("fclt_name"),
-            "addr": r.get("addr"),
+            "addr": addr,
             "lat": float(lat) if lat is not None else None,
             "lng": float(lng) if lng is not None else None,
             "facilities": {k: _is_y(r.get(k)) for k in TOUR_FIELDS},


### PR DESCRIPTION
Close #9

## 문제
db 백엔드 쿼리가 01 통합DB 의 실제 `poi_tour_bf_facility` 컬럼과 달랐다. 그대로 두면 `POI_BACKEND=db` 로 전환하는 순간 `UndefinedColumn` 으로 관광지 조회가 통째로 실패한다.

| 코드 가정 | 실제 |
|---|---|
| `addr` | `addr_road` / `addr_jibun` |
| `dis_toilet_yn` | `toilet_yn` |
| `dis_parking_yn` | `parking_yn` |
| — | `subway_yn`, `bus_stop_yn` |

## 조치
- 실제 스키마 기준 컬럼·필터 수정 (주소는 도로명/지번 양쪽 + LIKE 이스케이프)
- 장애 유형별 요구 편의시설 매핑도 실제 필드명으로 갱신

## 검증 (실 DB, iitp_dev)
- `/tour/bf-spots?sigungu=안양` -> **13건** (08 `--ext-sys TOUR_BF_API` 수집분)
- `/tour/recommend` (지체장애) -> 김중업 건축박물관 0.8 / 안양도시공사 빙상장 0.8 / 안양문화원 0.6
- `/route/plan` 안양시청 -> 평촌중앙공원: 796m / 18분 / 계단 0 / 최대경사 2.64° / 턴바이턴 12스텝
- pytest 30건 통과

## 참고
목적지 좌표가 `facility_centroid` 로 해석된다 — 무장애 출입구 좌표(`poi_facility_accessibility`)가 아직 적재되지 않았기 때문이다. 건물 중심으로 안내되므로 현장 실증 전에 보강이 필요하다.