### PR TITLE
v1.5.0 - 경로 API 서비스 컨테이너화

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git/
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+tests/
+data/
+*.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# 02-IITP-DABT-Route — 무장애 보행 경로 추천 API 서비스 이미지
+#
+# 그래프 구축(osmnx/rasterio/geopandas)은 이 이미지에 포함하지 않는다.
+# 구축은 오프라인 작업이고, 서비스는 완성된 그래프(.gpickle)와 건물 폴리곤(.pkl)만 읽는다.
+# 데이터는 볼륨으로 주입한다(이미지 재빌드 없이 그래프 교체 가능).
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY route_service/ ./route_service/
+COPY scripts/ ./scripts/
+
+EXPOSE 18100
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:18100/health || exit 1
+
+CMD ["uvicorn", "route_service.api.main:app", "--host", "0.0.0.0", "--port", "18100"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.4.0 |
+| 02-IITP-DABT-Route | v1.5.0 |
 
 ## 구조
 
@@ -57,6 +57,27 @@ python scripts/inspect_network.py --network data/network_anyang.gpickle \
     --route 37.4025,126.9227,37.3856,126.9256
 
 uvicorn route_service.api.main:app --host 0.0.0.0 --port 18100
+```
+
+### 컨테이너로 실행
+
+그래프 구축 의존성(osmnx·rasterio·geopandas)은 이미지에 넣지 않는다. 구축은 오프라인 작업이고,
+서비스는 완성된 그래프와 건물 폴리곤만 읽는다. **데이터는 볼륨으로 주입**하므로 이미지를 다시
+빌드하지 않고도 그래프를 교체할 수 있다.
+
+```bash
+docker build -t route-api .
+docker run -d --name route-api -p 18100:18100 \
+    -v "$PWD/data:/app/data:ro" \
+    -e NETWORK_PATH=/app/data/network_anyang.gpickle \
+    -e BUILDINGS_PATH=/app/data/buildings_anyang.pkl \
+    -e ENTRANCES_PATH=/app/data/poi/entrances.json \
+    -e POI_BACKEND=db \
+    -e POI_DB_DSN='postgresql+psycopg2://<user>:<pw>@<host>:5432/<db>' \
+    route-api
+
+curl -s localhost:18100/health
+curl -s localhost:18100/meta/network
 ```
 
 ## API


### PR DESCRIPTION
Close #13

## 변경
- `Dockerfile` — python:3.12-slim + **서비스 의존성만**(fastapi·uvicorn·networkx·sqlalchemy). 그래프 구축 의존성(osmnx·rasterio·geopandas·scipy)은 제외했다. 구축은 오프라인 작업이고 서비스는 완성된 그래프(.gpickle)·건물 폴리곤(.pkl)만 읽는다.
- **데이터는 볼륨 주입** — 이미지 재빌드 없이 그래프 교체 가능(융기원 원본 도착 시 파일만 바꾸면 됨).
- 헬스체크(`/health`) 포함, `.dockerignore` 로 데이터·테스트·가상환경 제외.

## 검증
pytest 32건 통과.