### PR TITLE
v1.5.1 - 컨테이너 기동 실패 수정 (shapely 런타임 의존성 + 로드 실패 격리)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.5.0 |
+| 02-IITP-DABT-Route | v1.5.1 |
 
 ## 구조
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ fastapi>=0.110
 uvicorn[standard]>=0.27
 pydantic>=2.5
 networkx>=3.1
+# 건물 폴리곤(접근점 해석) 로드에 필요 — 없으면 접근점 해석이 비활성화된다
+shapely>=2.0
 
 # POI: db 백엔드 사용 시
 SQLAlchemy>=2.0

--- a/route_service/engine/access.py
+++ b/route_service/engine/access.py
@@ -21,12 +21,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import pickle
 
 from .geo import haversine_m
 from .snap import snap
+
+logger = logging.getLogger("route_access")
 
 
 class BuildingIndex:
@@ -36,7 +39,12 @@ class BuildingIndex:
         self.polys = []          # [(shapely Polygon, name)]
         self.loaded = False
         if path and os.path.exists(path):
-            self.load(path)
+            try:
+                self.load(path)
+            except Exception as e:  # shapely 미설치·파일 손상 등
+                # 접근점 해석은 부가 기능이다. 실패해도 경로 안내 자체는 계속돼야 하므로
+                # 서비스를 죽이지 않고 비활성화한다(목적지는 시설 대표점으로 해석).
+                logger.warning("건물 폴리곤 로드 실패 — 접근점 해석 비활성화 (%s)", e)
 
     def load(self, path: str):
         with open(path, "rb") as f:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,3 +198,14 @@ def test_plan_reports_destination_note(client):
     assert d["resolved_by"] in ("manual_survey", "accessible_entrance",
                                 "building_access", "facility_centroid")
     assert d["note"]
+
+
+def test_missing_building_index_does_not_kill_service(tmp_path):
+    """건물 폴리곤 로드 실패는 부가 기능 손실일 뿐, 서비스를 죽이면 안 된다."""
+    from route_service.engine.access import BuildingIndex
+
+    bad = tmp_path / "broken.pkl"
+    bad.write_bytes(b"not a pickle")
+    idx = BuildingIndex(str(bad))
+    assert idx.loaded is False
+    assert idx.containing(37.39, 126.95) is None


### PR DESCRIPTION
Close #15

## 원인
건물 폴리곤 pickle 은 shapely 지오메트리를 담고 있어 역직렬화에 shapely 가 필요한데, 서비스 이미지에는 빠져 있었다(빌드 전용 의존성으로 분류). 실제 컨테이너 기동 시 `ModuleNotFoundError: No module named 'shapely'` 로 재시작 루프.

## 조치
- `requirements.txt` 에 shapely 추가
- `BuildingIndex` 로드 실패를 **예외로 터뜨리지 않고 경고 후 비활성화** — 접근점 해석은 부가 기능이므로 실패해도 경로 안내 자체는 계속돼야 한다(목적지는 시설 대표점으로 해석)
- 회귀 테스트 추가(손상된 인덱스 파일로도 기동 가능)

## 검증
pytest 33건 통과. 검증 서버 컨테이너 재빌드 후 기동 확인 예정.