### PR TITLE
v1.7.0 - 수치지형도(1:1,000) 보행망 파이프라인 + OSM 그래프 실측 폭·재질 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.6.0 |
+| 02-IITP-DABT-Route | v1.7.0 |
 
 ## 구조
 
@@ -58,6 +58,31 @@ python scripts/inspect_network.py --network data/network_anyang.gpickle \
 
 uvicorn route_service.api.main:app --host 0.0.0.0 --port 18100
 ```
+
+### 수치지형도(1:1,000) 속성 보강
+
+OSM 그래프의 보행 링크에 수치지형도 인도 면형의 **실측 폭·재질**을 전이한다
+(휠체어 프로필 `min_width` 를 추정치가 아닌 실측치로 판정).
+
+```bash
+# (a) OSM 횡단보도 확보 (인터넷 필요)
+python scripts/fetch_osm_crossings.py \
+    --place "Anyang-si, Gyeonggi-do, South Korea" --out data/osm_crossings.geojson
+
+# (b) 그래프 속성 보강 (1:1,000 우선, 1:5,000 폴백)
+python scripts/enrich_osm_with_topomap.py \
+    --graph data/network_anyang.gpickle \
+    --src-1k "<1:1,000 도엽 폴더>" --src-5k "<1:5,000 도엽 폴더>" \
+    --out data/network_anyang_enriched.gpickle
+```
+
+안양 실측(2026-07-16): 보행 링크 1,428건에 폭 채움(보도 44% · 횡단보도 76%),
+폭 중앙값 3.0m. road(이면도로) 링크는 차도 보행이라 보강 대상에서 제외.
+
+수치지형도 **단독** node/link 산출도 지원한다 (`scripts/build_pednet_from_topomap.py`,
+`route_service/topomap/` — NGI/NDA 자체 파서 + 면형 중심선화 + 위상 구축).
+단, 수치지형도에는 횡단보도 레이어가 없어(1:1,000·1:5,000 모두 실측 0건)
+단독 그래프는 블록 단위로 끊긴다 — 연결 골격은 OSM, 수치지형도는 속성 원천으로 쓴다.
 
 ### 컨테이너로 실행
 

--- a/route_service/topomap/__init__.py
+++ b/route_service/topomap/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""수치지형도(1:1,000) -> 보행망 구축 파이프라인.
+
+국토지리정보원 수치지도 Ver2.0 (SHP) 및 NGI/NDA 교환포맷을 읽어
+보도 중심선 + 위상(node/link)을 산출한다. 산출물은 engine.sources.tabular
+규격을 따르므로 build_network.py --source tabular 로 바로 투입된다.
+"""
+from .extract import extract_sheet, SIDEWALK_AREA, SIDEWALK_LINE, OVERPASS, ROAD_CENTER
+from .centerline import poly_to_centerlines
+from .dissolve import dissolve_polys, grid_centerlines
+from .topology import build_topology
+
+__all__ = ["extract_sheet", "poly_to_centerlines", "build_topology", "grid_centerlines",
+           "SIDEWALK_AREA", "SIDEWALK_LINE", "OVERPASS", "ROAD_CENTER"]

--- a/route_service/topomap/centerline.py
+++ b/route_service/topomap/centerline.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""보도 면형 -> 스켈레톤 중심선.
+
+수치지형도의 인도(A0033320)는 면형이라 그대로는 경로 그래프가 되지 않는다.
+폴리곤을 래스터화 후 skimage.skeletonize 로 골격을 뽑고 선형으로 되돌린다.
+폭(width)은 원본 속성을 그대로 전이하므로 면 폭에서 추정할 필요가 없다.
+"""
+from __future__ import annotations
+
+import numpy as np
+from shapely.geometry import Polygon, LineString
+from shapely.ops import linemerge, unary_union
+
+DEFAULT_RES = 1.0      # m/px. 보도 폭 중앙값 2.5m -> 2~3px, 골격 추출 가능한 최소 해상도
+MIN_LEN = 2.0          # 이보다 짧은 골격 조각은 버림 (스켈레톤 잔가지)
+SIMPLIFY_TOL = 1.0     # 픽셀 계단 제거 (res 에 맞춤)
+
+
+def _rings(points, parts):
+    ps = list(parts) + [len(points)]
+    out = []
+    for i in range(len(ps) - 1):
+        r = points[ps[i]:ps[i + 1]]
+        if len(r) >= 4:
+            out.append(r)
+    return out
+
+
+def _to_polygon(points, parts):
+    rings = _rings(points, parts)
+    if not rings:
+        return None
+    poly = Polygon(rings[0], rings[1:] if len(rings) > 1 else None)
+    if not poly.is_valid:
+        poly = poly.buffer(0)
+    return None if poly.is_empty else poly
+
+
+def poly_to_centerlines(points, parts, res: float = DEFAULT_RES,
+                        max_px: int = 20_000_000) -> list[LineString]:
+    """폴리곤 좌표열 -> 중심선 LineString 목록 (실패 시 빈 목록)."""
+    from skimage.draw import polygon as rr_polygon
+    from skimage.morphology import skeletonize
+
+    poly = _to_polygon(points, parts)
+    if poly is None:
+        return []
+    minx, miny, maxx, maxy = poly.bounds
+    pad = 2
+    W = int((maxx - minx) / res) + 2 * pad
+    H = int((maxy - miny) / res) + 2 * pad
+    if W < 3 or H < 3 or W * H > max_px:
+        return []
+    img = np.zeros((H, W), dtype=bool)
+    geoms = poly.geoms if poly.geom_type == "MultiPolygon" else [poly]
+    for g in geoms:
+        xs, ys = g.exterior.coords.xy
+        r, c = rr_polygon((np.array(ys) - miny) / res + pad,
+                          (np.array(xs) - minx) / res + pad, img.shape)
+        img[r, c] = True
+        for it in g.interiors:
+            xs, ys = it.coords.xy
+            r, c = rr_polygon((np.array(ys) - miny) / res + pad,
+                              (np.array(xs) - minx) / res + pad, img.shape)
+            img[r, c] = False
+    sk = skeletonize(img)
+    ys, xs = np.nonzero(sk)
+    if len(ys) < 2:
+        return []
+    pix = set(zip(ys.tolist(), xs.tolist()))
+    segs = []
+    for (y, x) in pix:
+        for dy, dx in ((0, 1), (1, 0), (1, 1), (1, -1)):
+            if (y + dy, x + dx) in pix:
+                segs.append(((minx + (x - pad) * res, miny + (y - pad) * res),
+                             (minx + (x + dx - pad) * res, miny + (y + dy - pad) * res)))
+    if not segs:
+        return []
+    merged = unary_union([LineString(s) for s in segs])
+    if merged.geom_type == "MultiLineString":
+        try:
+            merged = linemerge(merged)
+        except ValueError:      # 조각이 하나뿐이면 linemerge 가 거부한다
+            pass
+    lines = list(merged.geoms) if merged.geom_type == "MultiLineString" else [merged]
+    lines = [l for l in lines if l.geom_type == "LineString"]
+    out = []
+    for l in lines:
+        s = l.simplify(SIMPLIFY_TOL, preserve_topology=False)
+        if s.length > MIN_LEN:
+            out.append(s)
+    return out

--- a/route_service/topomap/crossings.py
+++ b/route_service/topomap/crossings.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""OSM 횡단보도 병합.
+
+수치지형도 1:1,000 에는 횡단보도 레이어가 없다(2026-07-16 안양 211매 전수 스캔 0건).
+인도 폴리곤 하나가 이미 한 블록 전체의 보도라서, 중심선을 뽑으면 블록마다 독립된
+선이 되고 교차로(실측 중앙값 13m 틈)에서 끊긴다. 즉 횡단보도 없이는 그래프가 이어지지 않는다.
+
+⚠️ 위상 구축 **이전에** 실행해야 한다. 노드는 블록 끝에만 있어(평균 52m 간격)
+횡단보도 끝점을 노드에 붙이려 하면 대부분 실패한다(실측: 623건 중 57건만 접합).
+대신 보도 **중심선 위의 최근접 지점**으로 투영해 T자 접합을 만들고,
+분할·스냅은 topology.build_topology 가 처리하게 한다.
+
+샌드박스는 overpass 접근이 차단되므로 scripts/fetch_osm_crossings.py 로
+로컬(Windows venv)에서 미리 받아 GeoJSON 으로 넘긴다.
+"""
+from __future__ import annotations
+
+import json
+import math
+
+from shapely.geometry import LineString, Point
+from shapely.strtree import STRtree
+
+SNAP_RADIUS = 30.0     # m — 횡단보도 끝점에서 보도 중심선을 찾는 반경
+MAX_SPAN = 60.0        # m — 이보다 긴 횡단보도 링크는 오접합으로 보고 버림
+
+
+def load_crossings(geojson_path: str, to_5186) -> list:
+    """OSM 횡단보도 GeoJSON(EPSG:4326) -> EPSG:5186 지오메트리 목록."""
+    with open(geojson_path, "r", encoding="utf-8") as f:
+        gj = json.load(f)
+    out = []
+    for feat in gj.get("features", []):
+        g = feat.get("geometry") or {}
+        if g.get("type") == "LineString":
+            pts = [to_5186(x, y) for x, y in g["coordinates"]]
+            if len(pts) >= 2:
+                out.append(LineString(pts))
+        elif g.get("type") == "Point":
+            out.append(Point(*to_5186(*g["coordinates"])))
+    return out
+
+
+def crossing_features(feats: list[dict], crossings: list,
+                      radius: float = SNAP_RADIUS) -> tuple[list[dict], dict]:
+    """보도 중심선 피처 + OSM 횡단보도 -> 횡단보도 링크 피처 목록.
+
+    반환: (crossing 피처 목록, 통계)
+    """
+    lines = [f for f in feats if f.get("kind") == "sidewalk"]
+    if not lines:
+        return [], {"linear": 0, "point": 0, "skipped": len(crossings)}
+    geoms = [f["geom"] for f in lines]
+    tree = STRtree(geoms)
+
+    out = []
+    stat = {"linear": 0, "point": 0, "skipped": 0}
+    for c in crossings:
+        if c.geom_type == "LineString":
+            seg = _from_line(c, tree, geoms, radius)
+        else:
+            seg = _from_point(c, tree, geoms, radius)
+        if seg is None:
+            stat["skipped"] += 1
+            continue
+        out.append({"kind": "crossing", "geom": seg, "width": None, "surface": None,
+                    "name": None, "accessible": None, "sheet": None, "osm": True})
+        stat["linear" if c.geom_type == "LineString" else "point"] += 1
+    return out, stat
+
+
+def _project(p: Point, tree, geoms, radius, exclude=None):
+    """점을 반경 안 최근접 보도 중심선 위로 투영. (투영점, 선 인덱스) 반환."""
+    best, bd = None, 1e18
+    for i in tree.query(p.buffer(radius)):
+        if exclude is not None and i == exclude:
+            continue
+        d = geoms[i].distance(p)
+        if d < bd:
+            best, bd = i, d
+    if best is None or bd > radius:
+        return None, None
+    g = geoms[best]
+    return g.interpolate(g.project(p)), best
+
+
+def _from_line(c: LineString, tree, geoms, radius):
+    """선형 횡단보도: 양 끝점을 각각 최근접 보도 중심선에 투영해 잇는다."""
+    a, ia = _project(Point(c.coords[0]), tree, geoms, radius)
+    b, ib = _project(Point(c.coords[-1]), tree, geoms, radius)
+    if a is None or b is None or ia == ib:
+        return None
+    if a.distance(b) < 1.0 or a.distance(b) > MAX_SPAN:
+        return None
+    return LineString([(a.x, a.y), (b.x, b.y)])
+
+
+def _from_point(c: Point, tree, geoms, radius):
+    """점형 횡단보도: 마주보는 두 보도 중심선에 투영해 잇는다."""
+    a, ia = _project(c, tree, geoms, radius)
+    if a is None:
+        return None
+    b, ib = _project(c, tree, geoms, radius, exclude=ia)
+    if b is None:
+        return None
+    # 같은 방향이면 도로를 건너는 게 아니다 (같은 쪽 보도 두 조각)
+    v1 = (a.x - c.x, a.y - c.y)
+    v2 = (b.x - c.x, b.y - c.y)
+    n1, n2 = math.hypot(*v1), math.hypot(*v2)
+    if n1 > 0.5 and n2 > 0.5:
+        cos = (v1[0] * v2[0] + v1[1] * v2[1]) / (n1 * n2)
+        if cos > -0.2:          # 100도 미만으로 벌어짐 = 마주보지 않음
+            return None
+    d = a.distance(b)
+    if d < 1.0 or d > MAX_SPAN:
+        return None
+    return LineString([(a.x, a.y), (b.x, b.y)])

--- a/route_service/topomap/dissolve.py
+++ b/route_service/topomap/dissolve.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""보도 면형 dissolve -> 연속 스트립 단위 스켈레톤화.
+
+폴리곤을 개별로 스켈레톤화하면 맞닿은 보도끼리도 중심선이 이어지지 않는다.
+스켈레톤은 폴리곤 경계에서 폭의 절반만큼 안쪽에서 끝나므로, 공유 경계를 사이에 둔
+두 중심선의 끝점이 (w1+w2)/2 만큼 벌어져 스냅 허용오차를 넘긴다.
+(2026-07-16 실측: 개별 스켈레톤화 시 연결요소 3,489개 / 최대 0.3% — 사용 불가)
+
+따라서 인접 폴리곤을 먼저 합쳐 연속 스트립을 만든 뒤 스트립 단위로 골격을 뽑는다.
+폭·재질은 골격 조각의 중점이 어느 원본 폴리곤에 속하는지 찾아 되돌려 붙인다.
+"""
+from __future__ import annotations
+
+from shapely.geometry import Polygon, MultiPolygon
+from shapely.ops import unary_union
+from shapely.strtree import STRtree
+
+SNAP_BUFFER = 0.05   # m — 부동소수 오차로 살짝 떨어진 인접 폴리곤을 붙인다
+
+
+def _to_polygon(points, parts):
+    ps = list(parts) + [len(points)]
+    rings = []
+    for i in range(len(ps) - 1):
+        r = points[ps[i]:ps[i + 1]]
+        if len(r) >= 4:
+            rings.append(r)
+    if not rings:
+        return None
+    poly = Polygon(rings[0], rings[1:] if len(rings) > 1 else None)
+    if not poly.is_valid:
+        poly = poly.buffer(0)
+    return None if poly.is_empty else poly
+
+
+def dissolve_polys(records: list[dict]) -> tuple[list, STRtree, list[dict]]:
+    """records: [{'points':..., 'parts':..., 'attrs':{...}, 'sheet':...}]
+
+    반환: (스트립 폴리곤 목록, 원본 STRtree, 원본 record 목록)
+    """
+    polys, srcs = [], []
+    for r in records:
+        p = _to_polygon(r["points"], r["parts"])
+        if p is None:
+            continue
+        polys.append(p)
+        srcs.append(r)
+    if not polys:
+        return [], None, []
+    merged = unary_union([p.buffer(SNAP_BUFFER) for p in polys])
+    strips = list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged]
+    strips = [s.buffer(-SNAP_BUFFER) for s in strips]
+    out = []
+    for s in strips:
+        if s.is_empty:
+            continue
+        if s.geom_type == "MultiPolygon":
+            out.extend([g for g in s.geoms if not g.is_empty and g.area > 1.0])
+        elif s.area > 1.0:
+            out.append(s)
+    return out, STRtree(polys), srcs
+
+
+def grid_centerlines(poly_records: list[dict], cell: float = 800.0,
+                     pad: float = 60.0, verbose: bool = True) -> list[dict]:
+    """보도 폴리곤 레코드 -> 중심선 피처 목록 (격자 분할 스켈레톤화).
+
+    전역 dissolve 한 보도는 도시 전체로 이어져 bbox 래스터가 수억 픽셀이 된다
+    (안양 9.7x11km / 0.5m = 4.3억 px -> OOM). 그렇다고 폴리곤을 그냥 잘라 처리하면
+    절단면에서 중심선이 폭의 절반만큼 물러나 다시 끊긴다.
+
+    그래서 격자 셀마다 **pad 만큼 넉넉히 확장한 영역**을 스켈레톤화한 뒤
+    **정확한 셀 경계로 선을 잘라낸다**. 골격이 경계를 가로질러 생성되므로
+    이웃 셀의 골격과 경계에서 정확히 만나고, 끝점 스냅으로 이어진다.
+    """
+    from .centerline import poly_to_centerlines
+    from .extract import _mk, SIDEWALK_AREA
+    from shapely.geometry import box
+
+    polys, srcs = [], []
+    for r in poly_records:
+        p = _to_polygon(r["points"], r["parts"])
+        if p is None:
+            continue
+        polys.append(p)
+        srcs.append(r)
+    if not polys:
+        return []
+    merged = unary_union([p.buffer(SNAP_BUFFER) for p in polys]).buffer(-SNAP_BUFFER)
+    tree = STRtree(polys)
+
+    # 셀마다 merged 전체와 교차하면 O(셀수 x 전체정점) 이라 사실상 끝나지 않는다.
+    # dissolve 결과를 조각 단위로 색인해 셀에 걸치는 조각만 교차시킨다.
+    mparts = list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged]
+    mtree = STRtree(mparts)
+
+    minx, miny, maxx, maxy = merged.bounds
+    out = []
+    nx_ = int((maxx - minx) // cell) + 1
+    ny_ = int((maxy - miny) // cell) + 1
+    done = 0
+    for ix in range(nx_):
+        for iy in range(ny_):
+            done += 1
+            if verbose and done % 20 == 0:
+                print(f"    셀 {done}/{nx_*ny_}  중심선 {len(out)}", flush=True)
+            x0 = minx + ix * cell
+            y0 = miny + iy * cell
+            cellbox = box(x0, y0, x0 + cell, y0 + cell)
+            outer = box(x0 - pad, y0 - pad, x0 + cell + pad, y0 + cell + pad)
+            hit = mtree.query(outer)
+            if len(hit) == 0:
+                continue
+            work = unary_union([mparts[i] for i in hit]).intersection(outer)
+            if work.is_empty:
+                continue
+            geoms = work.geoms if work.geom_type == "MultiPolygon" else [work]
+            for g in geoms:
+                if g.is_empty or g.area < 1.0:
+                    continue
+                pts, parts = _ring_coords(g)
+                if not pts:
+                    continue
+                for line in poly_to_centerlines(pts, parts):
+                    clipped = line.intersection(cellbox)
+                    if clipped.is_empty:
+                        continue
+                    segs = clipped.geoms if clipped.geom_type == "MultiLineString" else [clipped]
+                    for seg in segs:
+                        if seg.geom_type != "LineString" or seg.length < 1.0:
+                            continue
+                        out.append(_attach(seg, tree, polys, srcs))
+    return out
+
+
+def _ring_coords(poly):
+    pts = list(poly.exterior.coords)
+    parts = [0]
+    for it in poly.interiors:
+        parts.append(len(pts))
+        pts.extend(list(it.coords))
+    return pts, parts
+
+
+def _attach(line, tree, polys, srcs):
+    """중심선 조각의 중점이 속한 원본 폴리곤에서 폭·재질·도엽을 되돌려 붙인다."""
+    from .extract import _mk, SIDEWALK_AREA
+    mid = line.interpolate(0.5, normalized=True)
+    best, bd = None, 1e18
+    for i in tree.query(mid.buffer(3.0)):
+        d = polys[i].distance(mid)
+        if d < bd:
+            best, bd = i, d
+        if d == 0:
+            break
+    attrs = srcs[best]["attrs"] if best is not None else {}
+    sheet = srcs[best]["sheet"] if best is not None else ""
+    return _mk(sheet, SIDEWALK_AREA, line, attrs, "sidewalk")

--- a/route_service/topomap/extract.py
+++ b/route_service/topomap/extract.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""도엽(zip/ngi) -> 보행망 원천 피처 추출.
+
+수치지도 Ver2.0 지형지물 코드 (2026-07-16 안양 211매 실측 기준):
+  A0033320  인도(면형, SHP) / 인도 중심선(선형, NGI 2017) — 폭·재질 보유
+  A0033330  자전거보행자겸용도로(선형) — 폭·재질·구분
+  A0063321  육교 — 형태=장애인이용여부(가능/불가)
+  A0020000  도로중심선 — 횡단보도 추정·하이브리드 연결의 기준선
+"""
+from __future__ import annotations
+
+import os
+import zipfile
+import tempfile
+from shapely.geometry import LineString
+
+SIDEWALK_AREA = "A0033320"
+SIDEWALK_LINE = "A0033330"
+OVERPASS = "A0063321"
+ROAD_CENTER = "A0020000"
+
+WANTED = (SIDEWALK_AREA, SIDEWALK_LINE, OVERPASS, ROAD_CENTER)
+
+
+def _f(v, default=None):
+    try:
+        f = float(str(v).strip())
+        return f if f > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _sheet_id(path: str) -> str:
+    import re
+    m = re.search(r"_(\d{9})_", os.path.basename(path))
+    return m.group(1) if m else os.path.basename(path)[:20]
+
+
+def _from_shp(zip_path: str) -> list[dict]:
+    """SHP 도엽 zip -> 피처 목록.
+
+    zip 내부 파일 명명은 두 규칙이 혼재한다 (2026-07-16 안양 186매 실측):
+      N1형   : N1A_A0033320.shp / N1L_A0020000.shp  (N1A=면, N1L=선) — 138매
+      평문형 : A0033320.shp / A0010000-L.shp          (-L=선, 무접미=shapeType 으로 판별) — 48매(전부 2022)
+    평문형을 놓치면 평촌 등 동안구 중심부가 통째로 빠진다 (실제 사고: OSM 횡단보도
+    623건 중 400건이 보도에서 200m 이탈 → 원인이 이 누락이었음).
+    """
+    import shapefile
+    from .centerline import poly_to_centerlines
+
+    out = []
+    sid = _sheet_id(zip_path)
+    with tempfile.TemporaryDirectory() as td:
+        try:
+            with zipfile.ZipFile(zip_path) as z:
+                z.extractall(td)
+        except zipfile.BadZipFile:
+            return out
+        for code in WANTED:
+            for path, want_geom in _layer_files(td, code):
+                try:
+                    r = shapefile.Reader(path, encoding="cp949", encodingErrors="replace")
+                except Exception:
+                    continue
+                # Windows 에서 Reader 가 파일을 물고 있으면 TemporaryDirectory 정리가
+                # PermissionError 로 죽는다 -> 메모리로 다 읽고 즉시 닫는다.
+                is_area = (want_geom == "area") if want_geom else (r.shapeType == 5)
+                fl = [x[0] for x in r.fields[1:]]
+                idx = {n: fl.index(n) for n in fl}
+                shapes_recs = list(zip(r.shapes(), r.records()))
+                r.close()
+                for sh, rec in shapes_recs:
+                    a = {n: rec[i] for n, i in idx.items()}
+                    if is_area and code == SIDEWALK_AREA:
+                        out.append({"sheet": sid, "code": code, "kind": "sidewalk_poly",
+                                    "points": sh.points, "parts": sh.parts, "attrs": a})
+                    elif is_area and code == OVERPASS:
+                        for l in poly_to_centerlines(sh.points, sh.parts):
+                            out.append(_mk(sid, code, l, a, "overpass"))
+                    elif not is_area:
+                        if len(sh.points) < 2:
+                            continue
+                        kind = {SIDEWALK_LINE: "sidewalk", ROAD_CENTER: "road"}.get(code)
+                        if not kind:
+                            continue
+                        out.append(_mk(sid, code, LineString(sh.points), a, kind))
+    return out
+
+
+def _layer_files(td: str, code: str):
+    """압축 해제 폴더에서 code 에 해당하는 shp 파일들을 (경로, 지오메트리 힌트) 로 나열."""
+    cands = [
+        (os.path.join(td, f"N1A_{code}.shp"), "area"),
+        (os.path.join(td, f"N1L_{code}.shp"), "line"),
+        (os.path.join(td, f"{code}.shp"), None),          # 평문형 — shapeType 으로 판별
+        (os.path.join(td, f"{code}-L.shp"), "line"),      # 평문형 선형
+    ]
+    return [(p, g) for p, g in cands if os.path.exists(p)]
+
+
+def _from_ngi(ngi_path: str) -> list[dict]:
+    from .ngi import read_ngi
+
+    out = []
+    sid = _sheet_id(ngi_path)
+    try:
+        layers = read_ngi(ngi_path)
+    except Exception:
+        return out
+    for code in WANTED:
+        L = layers.get(code)
+        if not L:
+            continue
+        kind = {SIDEWALK_AREA: "sidewalk", SIDEWALK_LINE: "sidewalk",
+                OVERPASS: "overpass", ROAD_CENTER: "road"}[code]
+        for feat in L["features"]:
+            g = feat["geom"]
+            for pts in g["parts"]:
+                if len(pts) < 2:
+                    continue
+                # NGI 2017 의 인도는 이미 중심선(LINESTRING) 이라 스켈레톤화 불필요
+                out.append(_mk(sid, code, LineString(pts), feat["attrs"], kind))
+    return out
+
+
+def _mk(sid: str, code: str, line: LineString, attrs: dict, kind: str) -> dict:
+    width = _f(attrs.get("폭") or attrs.get("도로폭"))
+    return {
+        "sheet": sid,
+        "code": code,
+        "kind": kind,
+        "geom": line,
+        "width": width,
+        "surface": (attrs.get("재질") or "").strip() or None,
+        "name": (attrs.get("명칭") or attrs.get("도로명") or "").strip() or None,
+        # 육교 A0063321 의 '형태' = 장애인이용여부(가능/불가)
+        "accessible": _access(attrs.get("형태")),
+        "ufid": (attrs.get("UFID") or "").strip() or None,
+    }
+
+
+def _access(v):
+    if not v:
+        return None
+    s = str(v)
+    if "가능" in s:
+        return True
+    if "불가" in s:
+        return False
+    return None
+
+
+def extract_sheet(path: str) -> list[dict]:
+    """도엽 파일(.zip=SHP / .ngi) -> 피처 목록."""
+    if path.lower().endswith(".zip"):
+        return _from_shp(path)
+    if path.lower().endswith(".ngi"):
+        return _from_ngi(path)
+    return []

--- a/route_service/topomap/ngi.py
+++ b/route_service/topomap/ngi.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""NGI/NDA(국토지리정보원 수치지도 교환포맷) 리더.
+
+GDAL 에 NGI 드라이버가 없어 자체 파싱한다.
+- .ngi : 레이어별 지오메트리 (POINT / LINESTRING / POLYGON, NUMPARTS 지원)
+- .nda : 레이어별 속성 ($ASPATIAL_FIELD_DEF + $RECORD n)
+두 파일은 레이어명 + $RECORD 번호로 조인한다. 인코딩은 CP949.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterator
+
+_NUM = re.compile(r"^-?\d+\.?\d*(?:[eE][-+]?\d+)?$")
+
+
+def _read(path: str) -> list[str]:
+    with open(path, "r", encoding="cp949", errors="replace") as f:
+        return f.read().splitlines()
+
+
+def _split_layers(lines: list[str]) -> Iterator[tuple[str, list[str]]]:
+    """<LAYER_START> ... 다음 <LAYER_START> 전까지를 한 레이어로 자른다."""
+    starts = [i for i, l in enumerate(lines) if l.strip() == "<LAYER_START>"]
+    for k, s in enumerate(starts):
+        e = starts[k + 1] if k + 1 < len(starts) else len(lines)
+        body = lines[s:e]
+        name = ""
+        for i, l in enumerate(body):
+            if l.strip() == "$LAYER_NAME":
+                name = body[i + 1].strip().strip('"')
+                break
+        yield name, body
+
+
+def _parse_ngi_geoms(body: list[str]) -> dict[int, dict]:
+    """레이어 본문 -> {record_no: {'type':..., 'parts':[[(x,y),...], ...]}}"""
+    out: dict[int, dict] = {}
+    i = 0
+    n = len(body)
+    cur = None
+    while i < n:
+        s = body[i].strip()
+        m = re.match(r"^\$RECORD\s+(\d+)$", s)
+        if m:
+            cur = int(m.group(1))
+            i += 1
+            continue
+        if cur is not None and s in ("POINT", "LINESTRING", "POLYGON", "MULTIPOINT",
+                                    "MULTILINESTRING", "MULTIPOLYGON", "TEXT"):
+            gtype = s
+            i += 1
+            nparts = 1
+            if i < n and body[i].strip().startswith("NUMPARTS"):
+                nparts = int(body[i].split()[1]); i += 1
+            parts = []
+            for _ in range(nparts):
+                # 좌표 개수 줄
+                while i < n and not _NUM.match(body[i].strip().split(" ")[0] or "x"):
+                    i += 1
+                if i >= n:
+                    break
+                cnt_line = body[i].strip()
+                if " " in cnt_line:      # POINT 는 개수 줄 없이 바로 좌표
+                    pts = []
+                    xy = cnt_line.split()
+                    pts.append((float(xy[0]), float(xy[1])))
+                    i += 1
+                    parts.append(pts)
+                    continue
+                cnt = int(cnt_line); i += 1
+                pts = []
+                for _ in range(cnt):
+                    if i >= n:
+                        break
+                    xy = body[i].split()
+                    if len(xy) >= 2 and _NUM.match(xy[0]):
+                        pts.append((float(xy[0]), float(xy[1])))
+                    i += 1
+                parts.append(pts)
+            if cur not in out and parts:
+                out[cur] = {"type": gtype, "parts": parts}
+            continue
+        i += 1
+    return out
+
+
+def _parse_nda_attrs(body: list[str]) -> tuple[list[str], dict[int, list]]:
+    fields: list[str] = []
+    for l in body:
+        m = re.match(r'^\s*ATTRIB\("([^"]*)"', l)
+        if m:
+            fields.append(m.group(1))
+    recs: dict[int, list] = {}
+    i = 0
+    while i < len(body):
+        m = re.match(r"^\$RECORD\s+(\d+)$", body[i].strip())
+        if m and i + 1 < len(body):
+            rid = int(m.group(1))
+            vals = _split_csv(body[i + 1])
+            recs[rid] = vals
+            i += 2
+            continue
+        i += 1
+    return fields, recs
+
+
+def _split_csv(line: str) -> list[str]:
+    out, buf, q = [], "", False
+    for ch in line:
+        if ch == '"':
+            q = not q
+        elif ch == "," and not q:
+            out.append(buf.strip()); buf = ""
+        else:
+            buf += ch
+    out.append(buf.strip())
+    return out
+
+
+def read_ngi(ngi_path: str, nda_path: str | None = None) -> dict[str, dict]:
+    """{layer_name: {'fields': [...], 'features': [{'geom':..., 'attrs': {...}}]}}"""
+    if nda_path is None:
+        nda_path = ngi_path[:-4] + ".nda"
+    geo_layers = {name: _parse_ngi_geoms(b) for name, b in _split_layers(_read(ngi_path))}
+    att_layers = {}
+    try:
+        att_layers = {name: _parse_nda_attrs(b) for name, b in _split_layers(_read(nda_path))}
+    except FileNotFoundError:
+        pass
+    out = {}
+    for name, geoms in geo_layers.items():
+        fields, recs = att_layers.get(name, ([], {}))
+        feats = []
+        for rid, g in sorted(geoms.items()):
+            vals = recs.get(rid, [])
+            attrs = dict(zip(fields, vals)) if fields else {}
+            feats.append({"geom": g, "attrs": attrs})
+        out[name] = {"fields": fields, "features": feats}
+    return out

--- a/route_service/topomap/topology.py
+++ b/route_service/topomap/topology.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""보도 중심선 조각 -> 위상 그래프(node/link).
+
+수치지형도는 위상이 없다. 도엽마다 독립 제작되어 경계에서 선이 끊기고,
+스켈레톤 중심선도 폴리곤 단위로 쪼개져 나온다. 여기서 다음을 처리한다.
+
+  1) 끝점 스냅   — tol 이내 끝점을 하나의 노드로 병합 (도엽 경계 접합 포함)
+  2) 교차 분할   — 선이 교차하면 교차점에서 링크를 나눠 노드 생성
+  3) 고립 제거   — min_component_len 미만 연결요소 폐기 (스켈레톤 잔가지)
+"""
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+
+from shapely.geometry import LineString, Point
+
+SNAP_TOL = 1.5            # m — 도엽 경계 어긋남·스켈레톤 끝단 오차 흡수
+MIN_COMPONENT_LEN = 30.0  # m — 이보다 짧은 고립 연결요소는 버림
+BRIDGE_GAP = 6.0          # m — 차량 진출입로로 끊긴 보도를 잇는 최대 틈 (도로 횡단은 OSM 횡단보도 담당)
+
+
+def _key(pt, tol):
+    return (round(pt[0] / tol), round(pt[1] / tol))
+
+
+def _split_at_intersections(feats: list[dict], tol: float) -> list[dict]:
+    """다른 선의 끝점이 어떤 선의 중간에 닿으면(T자 접합) 그 지점에서 분할.
+
+    스켈레톤 중심선은 이미 폴리곤 단위로 분절되어 있고 도엽 경계 접합은
+    끝점 스냅이 처리한다. 따라서 전역 noding(unary_union + linemerge)은 불필요하며,
+    오히려 linemerge 가 폭이 다른 보도들을 하나의 체인으로 병합해 속성을 뭉갠다.
+    여기서는 T자 접합만 국소적으로 분할한다.
+    """
+    from shapely.strtree import STRtree
+
+    work = [f for f in feats if f.get("kind") != "road"]
+    keep = [f for f in feats if f.get("kind") == "road"]
+    if not work:
+        return keep
+
+    geoms = [f["geom"] for f in work]
+    tree = STRtree(geoms)
+    out = list(keep)
+    for i, f in enumerate(work):
+        g = f["geom"]
+        cuts = []
+        for j in tree.query(g.buffer(tol)):
+            if j == i:
+                continue
+            og = work[j]["geom"]
+            for p in (Point(og.coords[0]), Point(og.coords[-1])):
+                if g.distance(p) > tol:
+                    continue
+                d = g.project(p)
+                if tol < d < g.length - tol:      # 끝점 근처는 스냅이 처리
+                    cuts.append(d)
+        if not cuts:
+            out.append(f)
+            continue
+        for piece in _cut_line(g, sorted(set(round(c, 2) for c in cuts))):
+            nf = dict(f)
+            nf["geom"] = piece
+            out.append(nf)
+    return out
+
+
+def _cut_line(line: LineString, dists: list[float]) -> list[LineString]:
+    """선을 진행거리 목록에서 잘라 조각들로 반환."""
+    pieces = []
+    prev = 0.0
+    for d in list(dists) + [line.length]:
+        if d - prev < 0.5:
+            continue
+        seg = _substring(line, prev, d)
+        if seg is not None and seg.length > 0.5:
+            pieces.append(seg)
+        prev = d
+    return pieces or [line]
+
+
+def _substring(line: LineString, s: float, e: float):
+    """line 의 진행거리 [s, e] 구간을 잘라낸다 (중간 정점 보존)."""
+    coords = list(line.coords)
+    pts = [(line.interpolate(s).x, line.interpolate(s).y)]
+    acc = 0.0
+    for k in range(len(coords) - 1):
+        seg_len = math.dist(coords[k], coords[k + 1])
+        a = acc
+        acc += seg_len
+        if a > s and a < e:
+            pts.append(tuple(coords[k]))
+    pts.append((line.interpolate(e).x, line.interpolate(e).y))
+    uniq = []
+    for p in pts:
+        if not uniq or p != uniq[-1]:
+            uniq.append(p)
+    if len(uniq) < 2:
+        return None
+    return LineString(uniq)
+
+
+def build_topology(feats: list[dict], to_wgs84, tol: float = SNAP_TOL,
+                   bridge_gap: float = BRIDGE_GAP,
+                   min_component_len: float = MIN_COMPONENT_LEN):
+    """피처 목록 -> (nodes, links).
+
+    to_wgs84(x, y) -> (lon, lat) 변환 함수를 받는다 (EPSG:5186 -> 4326).
+    """
+    import networkx as nx
+
+    feats = _split_at_intersections(feats, tol)
+    feats = [f for f in feats if f.get("kind") != "road"]
+
+    # 1) 끝점 스냅 -> 노드
+    #    격자 반올림(round(x/tol))은 경계를 사이에 둔 두 점을 갈라놓는다
+    #    (실측: 1.5m 이내인데 다른 노드가 된 끝점 734개). KD-tree + union-find 로 스냅.
+    from scipy.spatial import cKDTree
+
+    raw = []
+    for f in feats:
+        g = f["geom"]
+        if g.is_empty or g.length <= 0:
+            continue
+        cs = list(g.coords)
+        raw.append((cs[0], cs[-1], f, g.length))
+    if not raw:
+        return [], []
+
+    endpts = []
+    for a, b, _, _ in raw:
+        endpts.append(a); endpts.append(b)
+    tree = cKDTree(endpts)
+    parent = list(range(len(endpts)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x, y):
+        rx, ry = find(x), find(y)
+        if rx != ry:
+            parent[max(rx, ry)] = min(rx, ry)
+
+    for i, j in tree.query_pairs(tol):
+        union(i, j)
+
+    cluster_id, coords = {}, {}
+    for i in range(len(endpts)):
+        r = find(i)
+        if r not in cluster_id:
+            cluster_id[r] = len(cluster_id) + 1
+            coords[cluster_id[r]] = endpts[r]
+    nid_of = [cluster_id[find(i)] for i in range(len(endpts))]
+
+    G = nx.Graph()
+    edges = []
+    for k, (a, b, f, ln) in enumerate(raw):
+        na, nb = nid_of[2 * k], nid_of[2 * k + 1]
+        if na == nb:
+            continue
+        edges.append((na, nb, f, ln))
+        G.add_edge(na, nb, length=ln)
+
+    # 1-b) 진출입로 수준의 짧은 틈 잇기.
+    #      수치지형도의 인도 폴리곤은 차량 진출입로에서 물리적으로 끊긴다
+    #      (실측: 다른 연결요소와의 최근접 거리 중앙값 13m). 도로 횡단(>bridge_gap)은
+    #      OSM 횡단보도가 담당하고, 여기서는 진출입로만 잇는다.
+    if bridge_gap > 0:
+        cpts = [coords[i] for i in sorted(coords)]
+        cids = sorted(coords)
+        ct = cKDTree(cpts)
+        seq = len(edges)
+        for i, j in ct.query_pairs(bridge_gap):
+            a, b = cids[i], cids[j]
+            if G.has_edge(a, b):
+                continue
+            try:
+                if nx.shortest_path_length(G, a, b) <= 3:
+                    continue          # 이미 가까이 이어져 있으면 건너뜀
+            except (nx.NetworkXNoPath, nx.NodeNotFound):
+                pass
+            d = math.dist(cpts[i], cpts[j])
+            f = {"kind": "sidewalk", "width": None, "surface": None,
+                 "name": None, "accessible": None, "sheet": None, "bridged": True}
+            edges.append((a, b, f, d))
+            G.add_edge(a, b, length=d)
+
+    # 2) 고립 연결요소 제거
+    keep = set()
+    for comp in nx.connected_components(G):
+        sub = G.subgraph(comp)
+        tot = sum(d["length"] for _, _, d in sub.edges(data=True))
+        if tot >= min_component_len:
+            keep |= set(comp)
+
+    nodes, links = [], []
+    used = set()
+    for i, (a, b, f, ln) in enumerate(edges, 1):
+        if a not in keep or b not in keep:
+            continue
+        used.add(a); used.add(b)
+        lon1, lat1 = to_wgs84(*coords[a])
+        lon2, lat2 = to_wgs84(*coords[b])
+        links.append({
+            "LINK_ID": f"L{i:07d}",
+            "F_NODE": f"N{a:07d}",
+            "T_NODE": f"N{b:07d}",
+            "LENGTH": round(ln, 2),
+            "LINK_TYPE": f.get("kind", "sidewalk"),
+            "WIDTH": f.get("width"),
+            "SURFACE": f.get("surface"),
+            "LINK_NAME": f.get("name"),
+            "ACCESSIBLE": f.get("accessible"),
+            "SHEET": f.get("sheet"),
+            "SOURCE": "bridge" if f.get("bridged") else "topomap",
+        })
+    for n in sorted(used):
+        lon, lat = to_wgs84(*coords[n])
+        nodes.append({"NODE_ID": f"N{n:07d}", "X": round(lon, 8), "Y": round(lat, 8),
+                      "NODE_TYPE": "sidewalk"})
+    return nodes, links

--- a/scripts/build_pednet_from_topomap.py
+++ b/scripts/build_pednet_from_topomap.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""1:1,000 수치지형도 -> 보행망 node/link 산출.
+
+수치지형도(EPSG:5186)의 인도 면형·선형을 중심선화하고 위상을 구축한 뒤,
+OSM 횡단보도를 병합해 engine.sources.tabular 규격의 node/link 를 만든다.
+
+사용 예:
+  # 1) OSM 횡단보도 먼저 확보 (인터넷 필요 — 로컬 venv 에서 실행)
+  python scripts/fetch_osm_crossings.py --place "Anyang-si, Gyeonggi-do, South Korea" \
+      --out data/osm_crossings.geojson
+
+  # 2) 보행망 산출
+  python scripts/build_pednet_from_topomap.py \
+      --src "../91-조사설계_이동편의/경기도 안양시 지도/안양시 수치지형도/1_1000_2026-07-16" \
+      --crossings data/osm_crossings.geojson \
+      --out-node data/pednet_node.csv --out-link data/pednet_link.csv
+
+  # 3) 그래프 빌드
+  python scripts/build_network.py --source tabular \
+      --node data/pednet_node.csv --link data/pednet_link.csv \
+      --dem data/dem/anyang_5m.tif --out data/network_anyang_topo.gpickle \
+      --version anyang-topo1k-2026Q3
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from route_service.topomap import extract_sheet, build_topology, grid_centerlines  # noqa: E402
+from route_service.topomap.crossings import load_crossings, crossing_features  # noqa: E402
+
+SRC_EPSG = 5186
+
+
+def _transformers():
+    from pyproj import Transformer
+    fwd = Transformer.from_crs(f"EPSG:{SRC_EPSG}", "EPSG:4326", always_xy=True)
+    inv = Transformer.from_crs("EPSG:4326", f"EPSG:{SRC_EPSG}", always_xy=True)
+    return fwd.transform, inv.transform
+
+
+def _sheets(src: str) -> list[str]:
+    out = sorted(glob.glob(os.path.join(src, "**", "*.zip"), recursive=True))
+    out += sorted(glob.glob(os.path.join(src, "**", "*.ngi"), recursive=True))
+    # 공유 도엽(만안·동안 양쪽 배치)은 도엽번호 기준 1회만
+    seen, uniq = set(), []
+    import re
+    for p in out:
+        m = re.search(r"_(\d{9})_", os.path.basename(p))
+        k = m.group(1) if m else p
+        if k in seen:
+            continue
+        seen.add(k)
+        uniq.append(p)
+    return uniq
+
+
+def _write_csv(path, rows, cols):
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8-sig") as f:
+        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True, help="도엽 폴더 (zip/ngi 재귀 탐색)")
+    ap.add_argument("--crossings", help="OSM 횡단보도 GeoJSON (fetch_osm_crossings.py 산출)")
+    ap.add_argument("--out-node", default="data/pednet_node.csv")
+    ap.add_argument("--out-link", default="data/pednet_link.csv")
+    ap.add_argument("--snap-tol", type=float, default=1.5, help="끝점 스냅 허용오차(m)")
+    ap.add_argument("--min-component", type=float, default=30.0, help="고립 연결요소 최소 총연장(m)")
+    ap.add_argument("--limit", type=int, help="도엽 수 제한 (디버그)")
+    args = ap.parse_args()
+
+    to_wgs84, to_5186 = _transformers()
+    sheets = _sheets(args.src)
+    if args.limit:
+        sheets = sheets[:args.limit]
+    if not sheets:
+        sys.exit(f"도엽을 찾지 못했습니다: {args.src}")
+
+    t0 = time.time()
+    raw = []
+    for i, p in enumerate(sheets, 1):
+        raw.extend(extract_sheet(p))
+        if i % 25 == 0 or i == len(sheets):
+            print(f"  추출 {i}/{len(sheets)} 도엽, 피처 {len(raw)}", flush=True)
+    print(f"[1/4] 추출 완료: {len(raw)} 피처 ({time.time()-t0:.1f}s)")
+
+    polys = [f for f in raw if f.get("kind") == "sidewalk_poly"]
+    feats = [f for f in raw if f.get("kind") != "sidewalk_poly"]
+
+    # 보도 면형은 도엽 경계를 넘어 전역 dissolve 후 스트립 단위로 중심선화한다.
+    # (개별 폴리곤 스켈레톤화는 인접 보도끼리 이어지지 않아 그래프가 파편화된다)
+    t1 = time.time()
+    feats.extend(grid_centerlines(polys))
+    print(f"[2/4] 보도 dissolve·중심선화: 폴리곤 {len(polys)} -> "
+          f"중심선 {sum(1 for f in feats if f['kind']=='sidewalk')} ({time.time()-t1:.1f}s)")
+
+    kinds = {}
+    for f in feats:
+        kinds[f["kind"]] = kinds.get(f["kind"], 0) + 1
+    print(f"      종류별: {kinds}")
+
+    # 횡단보도는 위상 구축 **이전에** 붙인다. 보도 중심선 위로 투영해 T자 접합을
+    # 만들어두면 build_topology 의 분할·스냅이 그대로 이어준다.
+    if args.crossings and os.path.exists(args.crossings):
+        xs = load_crossings(args.crossings, to_5186)
+        cf, stat = crossing_features(feats, xs)
+        feats.extend(cf)
+        print(f"[3/4] 횡단보도 병합: OSM {len(xs)}건 -> {len(cf)} 링크 "
+              f"(선형 {stat['linear']} / 점형 {stat['point']} / 미접합 {stat['skipped']})")
+    else:
+        print("[3/4] 횡단보도 GeoJSON 미지정 — 병합 건너뜀 "
+              "(⚠️ 보도가 블록마다 끊긴 상태로 산출됩니다)")
+
+    nodes, links = build_topology(feats, to_wgs84, tol=args.snap_tol,
+                                  min_component_len=args.min_component)
+    print(f"[4/4] 위상 구축: 노드 {len(nodes)} / 링크 {len(links)}")
+
+    _write_csv(args.out_node, nodes, ["NODE_ID", "X", "Y", "NODE_TYPE"])
+    _write_csv(args.out_link, links,
+               ["LINK_ID", "F_NODE", "T_NODE", "LENGTH", "LINK_TYPE", "WIDTH",
+                "SURFACE", "LINK_NAME", "ACCESSIBLE", "SHEET", "SOURCE"])
+    tot = sum(l["LENGTH"] for l in links)
+    print(f"\n산출: {args.out_node} / {args.out_link}")
+    print(f"  노드 {len(nodes)} / 링크 {len(links)} / 총연장 {tot/1000:.1f} km "
+          f"({time.time()-t0:.1f}s)")
+
+
+def _coords_5186(nodes, to_5186):
+    return {n["NODE_ID"]: to_5186(n["X"], n["Y"]) for n in nodes}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enrich_osm_with_topomap.py
+++ b/scripts/enrich_osm_with_topomap.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""OSM 보행 그래프에 수치지형도 보도 속성(폭·재질)을 보강한다.
+
+전면 재검토(2026-07-16) 결론에 따른 하이브리드 구조:
+  - 연결 골격 = OSM 보행망 (횡단보도 포함, 위상 연결 보장)
+  - 속성 원천 = 수치지형도 인도 면형 (1:1,000 2022 우선, 1:5,000 2025 폴백)
+
+근거(실측):
+  - 수치지형도 단독 그래프는 횡단보도 부재로 최대 연결요소 4.6% — 경로탐색 불가
+  - 1:5,000(2025) 는 전 시가지 보도 커버 + 폭 100% 기재, 1:1,000(2022) 는 세밀하나 커버 구멍
+  - 두 연도(2022/2025) 보도망 형상은 중첩 구역에서 사실상 동일 — 연도 차이 실무 영향 미미
+
+사용:
+  python scripts/enrich_osm_with_topomap.py \
+      --graph data/network_anyang.gpickle \
+      --src-1k  "../91-조사설계_이동편의/경기도 안양시 지도/안양시 수치지형도/1_1000_2026-07-16" \
+      --src-5k  "../91-조사설계_이동편의/경기도 안양시 지도/안양시 수치지형도" \
+      --out data/network_anyang_enriched.gpickle
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import pickle
+import re
+import sys
+import tempfile
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+MATCH_RADIUS = 8.0    # m — OSM 링크 표본점에서 보도 폴리곤을 찾는 반경
+
+
+def _read_sidewalk_polys(zip_path: str, prefixes=("N1A_", "N3A_", "")):
+    """도엽 zip 에서 인도 면형(A0033320) 폴리곤·속성을 읽는다 (N1/N3/평문형 모두)."""
+    import shapefile
+    out = []
+    try:
+        zf = zipfile.ZipFile(zip_path)
+    except zipfile.BadZipFile:
+        return out
+    with tempfile.TemporaryDirectory() as td:
+        zf.extractall(td)
+        for pre in prefixes:
+            p = os.path.join(td, f"{pre}A0033320.shp")
+            if not os.path.exists(p):
+                continue
+            try:
+                r = shapefile.Reader(p, encoding="cp949", encodingErrors="replace")
+            except Exception:
+                continue
+            fl = [x[0] for x in r.fields[1:]]
+            wi = fl.index("폭") if "폭" in fl else None
+            si = fl.index("재질") if "재질" in fl else None
+            items = list(zip(r.shapes(), r.records()))
+            r.close()
+            for sh, rec in items:
+                w = rec[wi] if wi is not None else None
+                s = rec[si] if si is not None else None
+                out.append((sh.points, sh.parts,
+                            float(w) if isinstance(w, (int, float)) and w > 0 else None,
+                            str(s).strip() or None if s else None))
+            break
+    return out
+
+
+def _load_polys(src: str, digits: int):
+    from route_service.topomap.dissolve import _to_polygon
+    polys, attrs, seen = [], [], set()
+    pat = re.compile(r"_(\d{%d})_" % digits)
+    for z in sorted(glob.glob(os.path.join(src, "**", "*.zip"), recursive=True)):
+        m = pat.search(os.path.basename(z))
+        if not m or m.group(1) in seen:
+            continue
+        seen.add(m.group(1))
+        for points, parts, w, s in _read_sidewalk_polys(z):
+            g = _to_polygon(points, parts)
+            if g is None:
+                continue
+            polys.append(g)
+            attrs.append({"width": w, "surface": s})
+    return polys, attrs
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--src-1k", required=True, help="1:1,000 도엽 폴더 (9자리 도엽번호)")
+    ap.add_argument("--src-5k", help="1:5,000 도엽 폴더 (8자리 도엽번호, 폴백)")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--radius", type=float, default=MATCH_RADIUS)
+    args = ap.parse_args()
+
+    from pyproj import Transformer
+    from shapely.geometry import Point
+    from shapely.strtree import STRtree
+
+    inv = Transformer.from_crs("EPSG:4326", "EPSG:5186", always_xy=True).transform
+
+    print("[1/3] 수치지형도 보도 적재")
+    p1, a1 = _load_polys(args.src_1k, 9)
+    print(f"  1:1,000 폴리곤 {len(p1)}")
+    p5, a5 = ([], [])
+    if args.src_5k:
+        p5, a5 = _load_polys(args.src_5k, 8)
+        print(f"  1:5,000 폴리곤 {len(p5)}")
+    tiers = [("topo1k", STRtree(p1), p1, a1)] if p1 else []
+    if p5:
+        tiers.append(("topo5k", STRtree(p5), p5, a5))
+
+    print("[2/3] 그래프 링크 매칭")
+    with open(args.graph, "rb") as f:
+        G = pickle.load(f)
+
+    def _lonlat(n):
+        a = G.nodes[n]
+        if "lon" in a:
+            return a["lon"], a["lat"]
+        if "x" in a:
+            return a["x"], a["y"]
+        return None
+
+    def sample_pts(u, v, d):
+        """(lon, lat) 표본점. geometry 는 02 그래프에서 좌표쌍 list — 쌍 순서는
+        값 크기로 판별한다 (안양: lat≈37, lon≈127)."""
+        geom = d.get("geometry")
+        pts = []
+        if isinstance(geom, (list, tuple)) and len(geom) >= 2:
+            for pair in (geom[len(geom) // 4], geom[len(geom) // 2], geom[(3 * len(geom)) // 4]):
+                a, b = float(pair[0]), float(pair[1])
+                lon, lat = (a, b) if a > 90 else (b, a)
+                pts.append(Point(lon, lat))
+            return pts
+        if geom is not None and hasattr(geom, "interpolate"):
+            return [geom.interpolate(t, normalized=True) for t in (0.25, 0.5, 0.75)]
+        pu, pv = _lonlat(u), _lonlat(v)
+        if pu and pv:
+            return [Point((pu[0] + pv[0]) / 2, (pu[1] + pv[1]) / 2)]
+        return []
+
+    # road(이면도로)는 차도 보행이라 옆 보도의 폭을 옮기면 의미가 틀어진다 — 제외.
+    ENRICH_TYPES = {"sidewalk", "crossing", "steps", "overpass", "underpass",
+                    "ramp", "unknown"}
+
+    stat = {"edges": 0, "had_width": 0, "filled_width": 0, "filled_surface": 0,
+            "by_tier": {}}
+    for u, v, d in G.edges(data=True):
+        stat["edges"] += 1
+        if d.get("link_type") not in ENRICH_TYPES:
+            continue
+        if d.get("width"):
+            stat["had_width"] += 1
+        pts = [Point(*inv(p.x, p.y)) for p in sample_pts(u, v, d)]
+        if not pts:
+            continue
+        got = None
+        for tier, tree, polys, attrs in tiers:
+            best, bd = None, 1e18
+            for p in pts:
+                for i in tree.query(p.buffer(args.radius)):
+                    dd = polys[i].distance(p)
+                    if dd < bd:
+                        best, bd = i, dd
+            if best is not None and bd <= args.radius:
+                got = (tier, attrs[best])
+                break
+        if got is None:
+            continue
+        tier, a = got
+        stat["by_tier"][tier] = stat["by_tier"].get(tier, 0) + 1
+        if a["width"] and not d.get("width"):
+            d["width"] = a["width"]
+            stat["filled_width"] += 1
+        if a["surface"] and not d.get("surface"):
+            d["surface"] = a["surface"]
+            stat["filled_surface"] += 1
+        d["topo_source"] = tier
+
+    print("[3/3] 저장")
+    with open(args.out, "wb") as f:
+        pickle.dump(G, f)
+    print(f"  링크 {stat['edges']} / 기존 폭 보유 {stat['had_width']}"
+          f" / 폭 신규 채움 {stat['filled_width']} / 재질 채움 {stat['filled_surface']}")
+    print(f"  매칭 계층: {stat['by_tier']}")
+    print(f"  -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_osm_crossings.py
+++ b/scripts/fetch_osm_crossings.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""OSM 횡단보도 추출 -> GeoJSON.
+
+수치지형도에 횡단보도 레이어가 없어 OSM 기존 데이터로 보완한다.
+인터넷 접근이 필요하므로 로컬 venv 에서 실행한다 (샌드박스는 overpass 차단).
+
+  python scripts/fetch_osm_crossings.py \
+      --place "Anyang-si, Gyeonggi-do, South Korea" --out data/osm_crossings.geojson
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--place", default="Anyang-si, Gyeonggi-do, South Korea")
+    ap.add_argument("--bbox", help="min_lat,min_lng,max_lat,max_lng (place 대신)")
+    ap.add_argument("--out", default="data/osm_crossings.geojson")
+    args = ap.parse_args()
+
+    import osmnx as ox
+
+    tags = {"highway": "crossing", "footway": "crossing", "crossing": True}
+    if args.bbox:
+        s, w, n, e = [float(x) for x in args.bbox.split(",")]
+        gdf = ox.features_from_bbox((w, s, e, n), tags)
+    else:
+        gdf = ox.features_from_place(args.place, tags)
+
+    keep = gdf[gdf.geometry.type.isin(["LineString", "Point"])]
+    feats = []
+    for _, row in keep.iterrows():
+        g = row.geometry
+        feats.append({
+            "type": "Feature",
+            "geometry": json.loads(json.dumps(g.__geo_interface__)),
+            "properties": {
+                "crossing": str(row.get("crossing") or ""),
+                "tactile_paving": str(row.get("tactile_paving") or ""),
+                "kerb": str(row.get("kerb") or ""),
+            },
+        })
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump({"type": "FeatureCollection", "features": feats}, f, ensure_ascii=False)
+    n_line = sum(1 for x in feats if x["geometry"]["type"] == "LineString")
+    print(f"횡단보도 {len(feats)}건 (선형 {n_line} / 점형 {len(feats)-n_line}) -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #19

## 변경 요약
- `route_service/topomap/` 신설 — 수치지형도 1:1,000 (SHP Ver2.0 + NGI/NDA 교환포맷) 보행망 파이프라인
  - `ngi.py`: NGI/NDA 자체 파서 (GDAL 드라이버 부재, 25매 100% 파싱)
  - `extract.py`: 도엽 추출기 — **N1형/평문형 두 가지 zip 내부 명명규칙 모두 지원** (평문형 48매 누락 사고 수정)
  - `centerline.py`·`dissolve.py`: 인도 면형 -> 격자 분할 래스터 스켈레톤 중심선화 (폭·재질 속성 전이)
  - `topology.py`: KD-tree 끝점 스냅 + 차량 진출입로 틈(<=6m) 연결
  - `crossings.py`: OSM 횡단보도(선형/점형)를 보도 중심선에 투영 접합
- `scripts/build_pednet_from_topomap.py`: 단독 node/link 산출 CLI (tabular 어댑터 규격)
- `scripts/fetch_osm_crossings.py`: OSM 횡단보도 수집 (osmnx)
- `scripts/enrich_osm_with_topomap.py`: **OSM 그래프에 수치지형도 실측 폭·재질 보강** (1:1,000 우선 / 1:5,000 폴백, road 링크 제외)
- README: v1.7.0, 사용법 추가

## 아키텍처 판단 (실측 근거)
- 수치지형도에는 횡단보도 레이어가 **양 축척 모두 없음** (1:1,000 211매 + 1:5,000 23매 전수 스캔 0건) -> 단독 그래프는 최대 연결요소 4.6%로 경로탐색 불가
- 1:1,000(2022)과 1:5,000(2025) 보도망 형상은 중첩 구역에서 사실상 동일 — 연도 차 실무 영향 미미. 1:5,000 이 전 시가지 커버 + 폭 100% 기재라 폴백 원천으로 채택
- 결론: **연결 골격 = 기존 OSM 그래프 / 수치지형도 = 속성 원천** 하이브리드

## 실측 결과 (안양, 2026-07-16)
- 기존 그래프 폭 보유 5링크 -> 보강 후 보행 링크 1,428건 실측 폭 (보도 44% / 횡단보도 76%, 중앙값 3.0m)
- 연결성 영향 없음 (연결요소 1개 유지)

## 테스트
- `python -m compileall route_service scripts tests` 통과
- `pytest -q` 32 passed
- 실데이터 211매 파이프라인 완주 (Windows venv, 산출물은 data/ — 커밋 제외)