### PR TITLE
v1.8.0 - 보행망 node/link 통합DB 산출 스키마·스크립트 (mv_pednet_*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.7.0 |
+| 02-IITP-DABT-Route | v1.8.0 |
 
 ## 구조
 
@@ -83,6 +83,18 @@ python scripts/enrich_osm_with_topomap.py \
 `route_service/topomap/` — NGI/NDA 자체 파서 + 면형 중심선화 + 위상 구축).
 단, 수치지형도에는 횡단보도 레이어가 없어(1:1,000·1:5,000 모두 실측 0건)
 단독 그래프는 블록 단위로 끊긴다 — 연결 골격은 OSM, 수치지형도는 속성 원천으로 쓴다.
+
+### 통합DB 적재 (mv_pednet_node / mv_pednet_link)
+
+보강 그래프를 node/link 테이블로 산출해 통합DB(iitp_db)에 적재한다
+(스키마: `scripts/sql/pednet_schema.sql`, 명명은 기존 `mv_poi` 의 `mv_` 규약).
+
+```bash
+python scripts/export_graph_tables.py \
+    --graph data/network_anyang_enriched.gpickle \
+    --out-dir data/db_export --version anyang-topo-enrich-2026Q3
+# 이후 psql: schema 적용 -> \copy 로 CSV 적재 (동일 network_version 재적재 시 DELETE 선행)
+```
 
 ### 컨테이너로 실행
 

--- a/scripts/export_graph_tables.py
+++ b/scripts/export_graph_tables.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""보행 그래프(gpickle) -> node/link 테이블(CSV) 산출.
+
+통합DB(iitp_db)의 mv_pednet_node / mv_pednet_link 적재용.
+스키마는 scripts/sql/pednet_schema.sql 과 1:1 대응한다.
+
+  python scripts/export_graph_tables.py \
+      --graph data/network_anyang_enriched.gpickle \
+      --out-dir data/db_export --version anyang-topo-enrich-2026Q3
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import pickle
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--out-dir", default="data/db_export")
+    ap.add_argument("--version", required=True, help="네트워크 버전 태그 (테이블에 기록)")
+    args = ap.parse_args()
+
+    with open(args.graph, "rb") as f:
+        G = pickle.load(f)
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    node_path = os.path.join(args.out_dir, "mv_pednet_node.csv")
+    link_path = os.path.join(args.out_dir, "mv_pednet_link.csv")
+
+    with open(node_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["node_id", "lat", "lon", "node_type", "network_version"])
+        for n, d in G.nodes(data=True):
+            w.writerow([n, d.get("lat"), d.get("lon"),
+                        d.get("node_type") or "unknown", args.version])
+
+    def _b(v):
+        return {True: "true", False: "false"}.get(v, "")
+
+    with open(link_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["f_node", "t_node", "length_m", "link_type", "width_m",
+                    "slope_pct", "surface", "curb_cut", "link_name",
+                    "topo_source", "network_version"])
+        for u, v, d in G.edges(data=True):
+            w.writerow([
+                u, v, round(float(d.get("length") or 0), 2),
+                d.get("link_type") or "unknown",
+                d.get("width") or "",
+                d.get("slope") if d.get("slope") is not None else "",
+                d.get("surface") or "",
+                _b(d.get("curb_cut")),
+                d.get("link_name") or "",
+                d.get("topo_source") or "",
+                args.version,
+            ])
+
+    print(f"노드 {G.number_of_nodes()} -> {node_path}")
+    print(f"링크 {G.number_of_edges()} -> {link_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sql/pednet_schema.sql
+++ b/scripts/sql/pednet_schema.sql
@@ -1,0 +1,36 @@
+-- 보행망 node/link (02-IITP-DABT-Route v1.8.0)
+-- 원천: OSM 보행망 골격 + 수치지형도(1:1,000/1:5,000) 실측 폭·재질 보강
+-- 명명: 기존 mv_poi 와 동일한 mv_ (mobility) 접두 규약
+
+CREATE TABLE IF NOT EXISTS mv_pednet_node (
+    node_id         VARCHAR(20)  NOT NULL,
+    lat             DOUBLE PRECISION NOT NULL,
+    lon             DOUBLE PRECISION NOT NULL,
+    node_type       VARCHAR(20)  NOT NULL DEFAULT 'unknown',
+    network_version VARCHAR(40)  NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (network_version, node_id)
+);
+
+CREATE TABLE IF NOT EXISTS mv_pednet_link (
+    link_seq        BIGSERIAL PRIMARY KEY,
+    f_node          VARCHAR(20)  NOT NULL,
+    t_node          VARCHAR(20)  NOT NULL,
+    length_m        NUMERIC(8,2) NOT NULL,
+    link_type       VARCHAR(20)  NOT NULL DEFAULT 'unknown',  -- sidewalk/road/crossing/steps/overpass/underpass/ramp/elevator
+    width_m         NUMERIC(5,2),           -- 수치지형도 실측 폭 (topo_source 있을 때)
+    slope_pct       NUMERIC(6,3),           -- DEM 경사
+    surface         VARCHAR(30),            -- 재질 (블록/아스콘 등)
+    curb_cut        BOOLEAN,                -- 턱낮춤 (현재 원천 없음 — 안양시청 횡단보도 데이터 확보 시 채움)
+    link_name       VARCHAR(100),
+    topo_source     VARCHAR(10),            -- topo1k / topo5k / NULL(OSM 원본)
+    network_version VARCHAR(40)  NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pednet_link_ver_type ON mv_pednet_link (network_version, link_type);
+CREATE INDEX IF NOT EXISTS idx_pednet_link_fnode    ON mv_pednet_link (network_version, f_node);
+CREATE INDEX IF NOT EXISTS idx_pednet_node_ver      ON mv_pednet_node (network_version);
+
+COMMENT ON TABLE mv_pednet_node IS '안양 보행망 노드 (02-Route, OSM+수치지형도 하이브리드)';
+COMMENT ON TABLE mv_pednet_link IS '안양 보행망 링크 — width_m/surface 는 수치지형도 실측(topo_source 참조)';


### PR DESCRIPTION
Closes #22

## 변경 요약
- `scripts/export_graph_tables.py`: 보강 그래프(gpickle) -> node/link CSV 산출
- `scripts/sql/pednet_schema.sql`: iitp_db `mv_pednet_node` / `mv_pednet_link` DDL (기존 `mv_poi` 명명 규약, network_version 별 관리)
- README: v1.8.0, DB 적재 사용법

## 운영 반영 (완료)
- iitp_db 적재: 노드 6,750 / 링크 9,712 (version=`anyang-topo-enrich-2026Q3`, 실측 폭 1,433 링크)
- 검증 서버 route-api 그래프 교체: NETWORK_PATH=network_anyang_enriched.gpickle — `/meta/network` 로 버전 확인, `wheelchair_manual` 실경로 4,039m 검증
- width_coverage 0.05% -> **14.75%** (보행 링크 기준 51%)

## 테스트
- compileall 통과, DDL 적용·\copy 적재 실측 완료