### PR TITLE
v1.10.0 - 지역 필터 시군구 정합 매칭 + 지하차도 회피·유턴 억제·접근점 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.9.0 |
+| 02-IITP-DABT-Route | v1.10.0 |
 
 ## 구조
 

--- a/route_service/engine/access.py
+++ b/route_service/engine/access.py
@@ -52,8 +52,14 @@ class BuildingIndex:
         self.loaded = True
         return len(self.polys)
 
-    def containing(self, lat: float, lng: float):
-        """점을 포함하는 건물. 없으면 25m 이내 최근접 건물."""
+    def containing(self, lat: float, lng: float, near_m: float = 40.0):
+        """점을 포함하는 건물. 없으면 near_m 이내 최근접 건물.
+
+        POI 대표점이 건물 폴리곤 살짝 밖(주차장·마당 쪽)에 찍힌 사례가 많아
+        25m 로는 놓치는 시설이 있었다(#27, resolved_by=facility_centroid).
+        40m 로 완화 — 시설 부지 규모에서 엉뚱한 옆 건물로 붙을 위험은
+        '최근접' 선택이 흡수한다.
+        """
         if not self.loaded:
             return None
         try:
@@ -72,7 +78,7 @@ class BuildingIndex:
         if best is None:
             return None
         # 도 -> m 근사 (위도 37도 기준)
-        if best_d * 88000 <= 25.0:
+        if best_d * 88000 <= near_m:
             return best
         return None
 

--- a/route_service/engine/graph.py
+++ b/route_service/engine/graph.py
@@ -43,6 +43,29 @@ EDGE_DEFAULTS = {
     "geometry": None,
 }
 
+# 링크 이름 -> 보행 부적합 시설 재분류 (#27).
+# 차량용 지하차도(예: "일번가지하차도")는 OSM 태그상 highway=road + tunnel 이라
+# 기존 빌드에서 link_type="road" 로 들어와 휠체어 회피(avoid=underpass)를 그대로
+# 통과했다. 이미 배포된 그래프(pickle·DB 산출본)를 재빌드 없이 바로잡기 위해
+# 로드 시점에 이름으로 재분류한다. 재빌드 시점에는 sources/osm.py 의 태그 분류가
+# 같은 결과를 낸다.
+_NAME_RECLASS = (
+    (("지하차도", "지하도", "지하보도"), "underpass"),
+    (("육교", "고가교"), "overpass"),
+)
+# 이름 재분류를 허용하는 기존 타입 — 명시 조사된 타입(crossing·steps 등)은 건드리지 않는다.
+_NAME_RECLASS_FROM = ("road", "sidewalk", "unknown")
+
+
+def _reclass_by_name(link_type: str, link_name) -> str:
+    if link_type not in _NAME_RECLASS_FROM or not link_name:
+        return link_type
+    name = str(link_name)
+    for keywords, new_type in _NAME_RECLASS:
+        if any(k in name for k in keywords):
+            return new_type
+    return link_type
+
 
 def normalize_graph(G: nx.Graph) -> nx.Graph:
     """소스별 편차를 흡수해 표준 스키마로 맞춘다. 기존 인천 gpickle 도 그대로 수용."""
@@ -53,6 +76,7 @@ def normalize_graph(G: nx.Graph) -> nx.Graph:
             data.setdefault(k, default)
         if data["link_type"] not in LINK_TYPES:
             data["link_type"] = "unknown"
+        data["link_type"] = _reclass_by_name(data["link_type"], data.get("link_name"))
         try:
             data["length"] = float(data["length"])
         except (TypeError, ValueError):

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -13,13 +13,40 @@ import uuid
 
 import networkx as nx
 
-from .geo import haversine_m, path_length_m, point_segment_dist_m
+from .geo import bearing_deg, haversine_m, path_length_m, point_segment_dist_m, turn_angle
 from .graph import edge_coords
 from .profiles import Profile
+
+# 유턴 판정 각도 — steps.py 의 턴바이턴 유턴 기준(150도)과 동일해야
+# "안내에는 유턴으로 뜨는데 탐색은 못 잡는" 불일치가 안 생긴다.
+UTURN_ANGLE_DEG = 150.0
+UTURN_RETRY = 3
 
 
 class NoRouteError(Exception):
     pass
+
+
+def _uturn_edges(G, path) -> set:
+    """경로에서 유턴(150도 이상 회차)이 발생하는 지점의 앞뒤 링크 집합.
+
+    노드 기반 A* 는 회전 비용을 모른다. 그 결과 지하차도 진입로를 타고 들어갔다가
+    되돌아 나오는 식의 경로(#27, 일번가지하차도 583m + 유턴)가 최단으로 뽑힌다.
+    탐색 후 기하로 유턴을 검출해 해당 링크에 페널티를 주고 재탐색하는 방식으로 억제한다.
+    """
+    edges = set()
+    prev_out = None
+    prev_edge = None
+    for u, v in zip(path[:-1], path[1:]):
+        coords = edge_coords(G, u, v)
+        in_b = bearing_deg(coords[0][0], coords[0][1], coords[1][0], coords[1][1])
+        out_b = bearing_deg(coords[-2][0], coords[-2][1], coords[-1][0], coords[-1][1])
+        if prev_out is not None and abs(turn_angle(prev_out, in_b)) >= UTURN_ANGLE_DEG:
+            edges.add(prev_edge)
+            edges.add(frozenset((u, v)))
+        prev_out = out_b
+        prev_edge = frozenset((u, v))
+    return edges
 
 
 def edge_passable(data: dict, profile: Profile, max_slope_deg: float) -> bool:
@@ -159,6 +186,25 @@ def plan(store, start_node, goal_node, profile: Profile, alternatives: int = 1,
         raise NoRouteError("통행 가능한 경로를 찾지 못했습니다")
 
     applied = fallback["applied_max_slope_deg"]
+
+    # 유턴 억제 재탐색 — 유턴 없는 경로가 나오면 채택, 끝까지 없으면 유턴 최소 경로.
+    uturn_pen = set()
+    best_n, best_path = len(_uturn_edges(G, primary)), primary
+    for _ in range(UTURN_RETRY):
+        if best_n == 0:
+            break
+        uturn_pen |= _uturn_edges(G, best_path)
+        try:
+            cand = _astar(G, start_node, goal_node, profile, applied, uturn_pen)
+        except (nx.NetworkXNoPath, nx.NodeNotFound):
+            break
+        if cand == best_path:
+            break
+        n = len(_uturn_edges(G, cand))
+        if n < best_n:
+            best_n, best_path = n, cand
+    primary = best_path
+
     routes = [primary]
 
     # 대안 경로: 1안의 링크에 페널티를 주고 재탐색 (중복 경로는 버림)

--- a/route_service/engine/profiles.py
+++ b/route_service/engine/profiles.py
@@ -49,7 +49,9 @@ PROFILES = {
         speed_mps=0.7,
         slope_factor=0.30,
         avoid=("steps", "overpass", "underpass"),
-        penalize={"crossing": 1.2, "ramp": 1.1},
+        # road 가중: 보도(sidewalk)가 있는 우회로가 있으면 이면도로·차도 통행을
+        # 뒤로 미룬다. 하드 차단이 아니라 가중이므로 보도 미비 구간은 여전히 통행 가능.
+        penalize={"crossing": 1.2, "ramp": 1.1, "road": 1.25, "unknown": 1.1},
         min_width_m=0.9,
         requires_curb_cut=True,
     ),
@@ -60,7 +62,7 @@ PROFILES = {
         speed_mps=1.1,
         slope_factor=0.15,
         avoid=("steps", "overpass", "underpass"),
-        penalize={"crossing": 1.1},
+        penalize={"crossing": 1.1, "road": 1.2, "unknown": 1.1},
         min_width_m=0.9,
         requires_curb_cut=True,
     ),

--- a/route_service/engine/sources/osm.py
+++ b/route_service/engine/sources/osm.py
@@ -56,6 +56,10 @@ def classify_link(tags: dict) -> str:
             return "underpass"
         return "sidewalk"
     if hw in ("residential", "service", "unclassified", "tertiary", "secondary", "primary"):
+        # 차량 도로의 터널 = 지하차도. 기존에는 "road" 로 분류되어 휠체어 회피
+        # (avoid=underpass)를 통과했다 — 583m 지하차도 경유 안내의 원인(#27).
+        if tunnel and tunnel != "no":
+            return "underpass"
         return "road"
     return "unknown"
 

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -59,6 +59,31 @@ def _is_y(v) -> bool:
     return str(v).strip().upper() in ("Y", "TRUE", "1")
 
 
+# 시·군·구 행정단위 접미사. "안양" 처럼 접미사 없이 들어온 지역명은 이 접미사를 붙인
+# 변형("안양시"/"안양군"/"안양구")으로만 주소를 대조한다. 단순 부분일치는 전남 장흥군
+# "안양면" 같은 타지역 주소까지 끌어온다(#26).
+_SIGUNGU_SUFFIXES = ("시", "군", "구")
+
+
+def sigungu_variants(sigungu: str) -> list:
+    """지역명 -> 주소 대조용 행정단위 토큰 목록.
+
+    "안양"   -> ["안양시", "안양군", "안양구"]
+    "안양시" -> ["안양시"]  (이미 행정단위 접미사가 있으면 그대로)
+    """
+    s = (sigungu or "").strip()
+    if not s:
+        return []
+    if s.endswith(_SIGUNGU_SUFFIXES):
+        return [s]
+    return [s + suf for suf in _SIGUNGU_SUFFIXES]
+
+
+def _addr_in_sigungu(addr: str, variants: list) -> bool:
+    a = addr or ""
+    return any(v in a for v in variants)
+
+
 class PoiStore:
     def __init__(self, backend: str = "none", data_dir: str = "", dsn: str = ""):
         self.backend = backend
@@ -103,9 +128,25 @@ class PoiStore:
     def list_tour_spots(self, sigungu: str = "", bbox=None, limit: int = 50) -> list:
         if self.backend == "none":
             return []
+        variants = sigungu_variants(sigungu)
         if self.backend == "file":
             rows = self._load_file("tour_bf.json")
         else:
+            # 지역 필터는 주소의 시·군·구 토큰 정합으로만 판정한다.
+            # LIKE '%안양%' 방식은 주소 전체를 보기 때문에 전남 장흥군 "안양면" 소재
+            # POI(거리 307km)까지 포함시켰다(#26). title 대조도 같은 이유로 지역
+            # 필터에서 제외한다(이름 검색은 get_tour_spot 의 이름 폴백이 담당).
+            sg_clause = ""
+            params = {"limit": limit}
+            if variants:
+                ors = []
+                for i, v in enumerate(variants):
+                    ors.append(
+                        "COALESCE(address_road, '') LIKE '%%' || :sg{0} || '%%'"
+                        " OR COALESCE(address_detail, '') LIKE '%%' || :sg{0} || '%%'".format(i)
+                    )
+                    params["sg%d" % i] = v
+                sg_clause = "AND (%s)" % " OR ".join(ors)
             rows = self._query(
                 """
                 SELECT poi_id,
@@ -118,20 +159,14 @@ class PoiStore:
                  WHERE language_code = 'ko'
                    AND latitude IS NOT NULL AND longitude IS NOT NULL
                    AND COALESCE(detail_json->>'accessible_facilities', '') <> ''
-                   AND (:sigungu = ''
-                        OR COALESCE(address_road, '') LIKE '%%' || :sigungu || '%%'
-                        OR COALESCE(address_detail, '') LIKE '%%' || :sigungu || '%%'
-                        OR title LIKE '%%' || :sigungu || '%%')
+                   {sg}
                  LIMIT :limit
-                """,
-                {"sigungu": sigungu or "", "limit": limit},
+                """.format(sg=sg_clause),
+                params,
             )
         out = [self._normalize_tour(r) for r in rows]
-        if sigungu and self.backend == "file":
-            out = [
-                r for r in out
-                if sigungu in (r.get("addr") or "") or sigungu in (r.get("name") or "")
-            ]
+        if variants and self.backend == "file":
+            out = [r for r in out if _addr_in_sigungu(r.get("addr"), variants)]
         if bbox:
             min_lat, min_lng, max_lat, max_lng = bbox
             out = [

--- a/tests/test_route_quality.py
+++ b/tests/test_route_quality.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""경로 품질 회귀 테스트 (#26, #27).
+
+- #26: sigungu 부분일치가 타지역 '안양면'까지 포함하던 문제
+- #27: 지하차도(road 분류) 경유·유턴 경로가 최단으로 뽑히던 문제
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import networkx as nx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from route_service.engine.graph import NetworkStore  # noqa: E402
+from route_service.engine.planner import _uturn_edges, plan  # noqa: E402
+from route_service.engine.profiles import get_profile  # noqa: E402
+from route_service.poi.store import PoiStore, sigungu_variants  # noqa: E402
+
+
+# ---------- #26 sigungu 정합 매칭 ----------
+
+def test_sigungu_variants_expand_bare_name():
+    assert sigungu_variants("안양") == ["안양시", "안양군", "안양구"]
+
+
+def test_sigungu_variants_keep_administrative_suffix():
+    assert sigungu_variants("안양시") == ["안양시"]
+    assert sigungu_variants("만안구") == ["만안구"]
+    assert sigungu_variants("") == []
+
+
+def test_tour_filter_excludes_other_region_myeon(tmp_path):
+    """전남 장흥군 '안양면' 소재 POI 가 sigungu='안양' 조회에 포함되면 안 된다."""
+    rows = [
+        {
+            "poi_id": "1", "name": "안양예술공원",
+            "addr": "경기도 안양시 만안구 예술공원로 131",
+            "latitude": 37.4093, "longitude": 126.9316,
+            "elevator_yn": "Y",
+        },
+        {
+            "poi_id": "4318", "name": "수문해수욕장",
+            "addr": "전라남도 장흥군 안양면 수문리",
+            "latitude": 34.5583, "longitude": 126.9843,
+            "elevator_yn": "Y",
+        },
+    ]
+    (tmp_path / "tour_bf.json").write_text(
+        json.dumps(rows, ensure_ascii=False), encoding="utf-8"
+    )
+    store = PoiStore(backend="file", data_dir=str(tmp_path))
+    out = store.list_tour_spots(sigungu="안양")
+    ids = {r["poi_id"] for r in out}
+    assert ids == {"1"}
+
+
+# ---------- #27 링크 이름 기반 재분류 ----------
+
+def _one_edge_graph(link_type: str, link_name: str) -> nx.Graph:
+    G = nx.Graph()
+    G.add_node("A", lat=37.39, lon=126.95, node_type="unknown")
+    G.add_node("B", lat=37.39, lon=126.951, node_type="unknown")
+    G.add_edge("A", "B", length=90.0, slope=0.0, link_type=link_type,
+               width=None, curb_cut=None, surface=None,
+               link_name=link_name, geometry=None)
+    return G
+
+
+@pytest.mark.parametrize("lt,name,expected", [
+    ("road", "일번가지하차도", "underpass"),
+    ("sidewalk", "만안지하도", "underpass"),
+    ("road", "안양육교", "overpass"),
+    ("unknown", "비산고가교", "overpass"),
+    ("road", "예시로", "road"),               # 일반 도로는 그대로
+    ("crossing", "중앙지하차도앞", "crossing"),  # 명시 조사 타입은 보존
+])
+def test_normalize_reclassifies_underpass_by_name(lt, name, expected):
+    s = NetworkStore()
+    s.load_graph_object(_one_edge_graph(lt, name))
+    assert s.graph["A"]["B"]["link_type"] == expected
+
+
+def test_wheelchair_avoids_named_underpass_link():
+    """이름으로 재분류된 지하차도 링크는 휠체어 경로에서 하드 차단된다."""
+    G = nx.Graph()
+    G.add_node("A", lat=37.3900, lon=126.9500, node_type="unknown")
+    G.add_node("B", lat=37.3900, lon=126.9520, node_type="unknown")
+    G.add_node("C", lat=37.3910, lon=126.9510, node_type="unknown")
+    # 지름길: 차량 지하차도 (기존 빌드에서 road 로 들어온 케이스)
+    G.add_edge("A", "B", length=100.0, slope=0.0, link_type="road",
+               width=None, curb_cut=None, surface=None,
+               link_name="일번가지하차도", geometry=None)
+    # 우회로: 보도
+    G.add_edge("A", "C", length=120.0, slope=0.0, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    G.add_edge("C", "B", length=120.0, slope=0.0, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    s = NetworkStore()
+    s.load_graph_object(G)
+    res = plan(s, "A", "B", get_profile("wheelchair_manual"))
+    assert res["routes"][0]["path"] == ["A", "C", "B"]
+
+
+# ---------- #27 유턴 억제 ----------
+
+def _uturn_graph() -> NetworkStore:
+    """유턴 지름길 vs 유턴 없는 우회로.
+
+        S ==(60m)== B     (동쪽으로 갔다가)
+        C ==(60m)== T     (되돌아 나오는 평행로 — B 에서 유턴)
+        S --(110m)-- D --(110m)-- T   (북쪽 우회, 유턴 없음)
+    """
+    G = nx.Graph()
+    G.add_node("S", lat=37.39000, lon=126.95000, node_type="unknown")
+    G.add_node("B", lat=37.39000, lon=126.95200, node_type="unknown")
+    G.add_node("C", lat=37.39005, lon=126.95000, node_type="unknown")
+    G.add_node("T", lat=37.39010, lon=126.94900, node_type="unknown")
+    G.add_node("D", lat=37.39060, lon=126.95000, node_type="unknown")
+    common = dict(slope=0.0, link_type="sidewalk", width=2.0, curb_cut=True,
+                  surface=None, link_name=None, geometry=None)
+    G.add_edge("S", "B", length=60.0, **common)   # 동진
+    G.add_edge("B", "C", length=60.0, **common)   # 서진 (S-B 와 역방향 = 유턴)
+    G.add_edge("C", "T", length=60.0, **common)
+    G.add_edge("S", "D", length=110.0, **common)
+    G.add_edge("D", "T", length=110.0, **common)
+    s = NetworkStore()
+    s.load_graph_object(G)
+    return s
+
+
+def test_uturn_edges_detected_on_switchback():
+    s = _uturn_graph()
+    edges = _uturn_edges(s.graph, ["S", "B", "C", "T"])
+    assert frozenset(("S", "B")) in edges
+    assert frozenset(("B", "C")) in edges
+
+
+def test_plan_prefers_route_without_uturn():
+    """길이상 최단(180m)이라도 유턴 경로 대신 유턴 없는 220m 우회로를 채택한다."""
+    s = _uturn_graph()
+    res = plan(s, "S", "T", get_profile("wheelchair_manual"))
+    path = res["routes"][0]["path"]
+    assert path == ["S", "D", "T"]
+    assert len(_uturn_edges(s.graph, path)) == 0


### PR DESCRIPTION
## 요약

실브라우저·모의주행 검증에서 나온 경로 품질 결함 2건(#26, #27)을 수정합니다.

## #26 — sigungu LIKE '안양' 이 전남 장흥군 '안양면'까지 매칭

- 지역 필터를 주소 전체 부분일치에서 **시·군·구 행정단위 토큰 정합**으로 교체 (`sigungu_variants`: "안양" → 안양시/안양군/안양구)
- title 대조는 지역 필터에서 제외 (이름 검색은 `get_tour_spot` 이름 폴백이 담당)
- db·file 백엔드 동일 로직 적용

## #27 — 지하차도 유턴 경유·건물 중심 도착

**1) 지하차도 회피 (근본 원인 수정)**
- 원인: 차량 지하차도가 OSM `highway=road + tunnel` 이라 `link_type="road"` 로 분류 → 휠체어 회피(`avoid=underpass`)를 통과
- 그래프 **로드 시점에 링크 이름으로 재분류** ("지하차도/지하도" → underpass, "육교/고가교" → overpass) — 배포된 그래프 재빌드 없이 즉시 효력
- 재빌드 정합: `classify_link` 에서 차량 도로 + tunnel → underpass
- 휠체어 프로필에 road/unknown 가중(1.1~1.25) 추가 — 보도 우선, 하드 차단 아님

**2) 유턴 억제**
- 노드 기반 A* 는 회전 비용을 모르므로, 탐색 후 링크 기하로 유턴(150도 이상 회차, steps.py 유턴 판정과 동일 기준)을 검출해 해당 링크에 페널티를 주고 최대 3회 재탐색
- 유턴 없는 경로 우선 채택, 없으면 유턴 최소 경로

**3) 건물 접근점 보강**
- 최근접 건물 탐색 반경 25m → 40m (대표점이 폴리곤 밖 부지에 찍힌 시설 커버, `resolved_by=facility_centroid` 감소)

미해결 잔여분: crossing 미분류(도심 1.8km crossing_cnt=0)는 횡단보도 데이터 공백이 원인 — 안양시청 좌표본 제공신청 진행 중, 수령 후 별도 작업.

## 검증

- `py_compile` 7개 파일 통과
- pytest **46건 전부 통과** (기존 38 + 신규 8: sigungu 변형·안양면 배제·이름 재분류 6케이스·지하차도 회피·유턴 검출·유턴 억제 경로 채택)
- 신규 회귀 테스트: `tests/test_route_quality.py`

## 해결된 이슈

Closes #26
부분 해결 #27 (crossing 태깅은 시청 좌표본 수령 후)