### PR TITLE
v1.10.0 릴리즈

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.8.0 |
+| 02-IITP-DABT-Route | v1.9.0 |
 
 ## 구조
 
@@ -131,7 +131,7 @@ curl -s localhost:18100/meta/network
 | GET | `/tour/bf-spots` | 무장애 관광지 목록 |
 | GET | `/tour/bf-spots/{id}` | 관광지 상세 (편의시설 Y/N) |
 | GET | `/tour/bf-spots/{id}/entrance` | **무장애 접근 지점** — 실측 출입구 > 건물 접근점 > 시설 대표점 |
-| POST | `/tour/recommend` | 장애 유형별 관광지 추천 랭킹 |
+| POST | `/tour/recommend` | 장애 유형별 관광지 추천 랭킹 — `origin_lat/lng` 지정 시 **거리 오름차순**, `offset` 페이징(`total`/`has_more` 반환) |
 | GET | `/transit/access-points` | 휠체어 접근 가능한 정류장·역 |
 | POST | `/admin/reload-network` | 그래프 무중단 교체 |
 
@@ -230,7 +230,7 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 |---|---|---|
 | 보행 네트워크 | **OSM 안양 보행망** — 노드 6,750 / 링크 9,712 | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
 | 경사 | **5m DEM** — 1:5,000 수치지형도 등고선(주곡선 5m)을 보간해 생성 (`scripts/dem_from_contours.py`) | 공개DEM 90m(`.img`)도 그대로 사용 가능. DEM 이 아예 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
-| 무장애 관광지 | 01-IITP-DABT-Database `poi_tour_bf_facility` (`POI_BACKEND=db`) — **안양 13건 적재 완료** | 08 파이프라인(`--ext-sys TOUR_BF_API`)이 수집. 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
+| 무장애 관광지 | 01-IITP-DABT-Database `mv_poi` 정본 (`POI_BACKEND=db`) — 한국어 시설 문구를 `*_yn` 체계로 정규화(`MVPOI_FACILITY_MAP`), **안양 31건 실측** | 08 파이프라인이 수집·적재. 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
 | 역·정류장 | `poi_station_access_status` 등 — **미적재** | 적재 전까지 `/transit/access-points` 는 빈 결과 |
 
 ### 안양 그래프 실측 (v1.3.0)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.9.0 |
+| 02-IITP-DABT-Route | v1.10.0 |
 
 ## 구조
 

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -354,9 +354,17 @@ def tour_spot_entrance(poi_id: str, profile: str = Query("wheelchair_manual")):
 @app.post("/tour/recommend", tags=["tour"], dependencies=[Depends(auth)])
 def tour_recommend(req: RecommendRequest):
     items = poi_store.STORE.recommend_tour(
-        req.disabilities, req.sigungu, req.match_mode, req.topk
+        req.disabilities, req.sigungu, req.match_mode, req.topk,
+        origin_lat=req.origin_lat, origin_lng=req.origin_lng, offset=req.offset,
     )
-    return {"source": poi_store.STORE.source, "count": len(items), "items": items}
+    # total 은 클라이언트가 무한스크롤 종료를 판단하는 근거 — offset+topk 로는 알 수 없다.
+    total = len(poi_store.STORE.recommend_tour(
+        req.disabilities, req.sigungu, req.match_mode, 10000,
+        origin_lat=req.origin_lat, origin_lng=req.origin_lng, offset=0,
+    ))
+    return {"source": poi_store.STORE.source, "count": len(items),
+            "total": total, "offset": req.offset,
+            "has_more": req.offset + len(items) < total, "items": items}
 
 
 # ────────────────────────── transit ──────────────────────────

--- a/route_service/api/schemas.py
+++ b/route_service/api/schemas.py
@@ -54,3 +54,7 @@ class RecommendRequest(BaseModel):
     sigungu: str = "안양"
     match_mode: str = Field("all", description="all | any")
     topk: int = Field(10, ge=1, le=50)
+    # 출발지를 주면 거리 오름차순으로 정렬한다(반경 제한 없음). 목록 무한스크롤용.
+    origin_lat: Optional[float] = None
+    origin_lng: Optional[float] = None
+    offset: int = Field(0, ge=0, description="거리순 목록에서 건너뛸 개수")

--- a/route_service/engine/access.py
+++ b/route_service/engine/access.py
@@ -52,8 +52,14 @@ class BuildingIndex:
         self.loaded = True
         return len(self.polys)
 
-    def containing(self, lat: float, lng: float):
-        """점을 포함하는 건물. 없으면 25m 이내 최근접 건물."""
+    def containing(self, lat: float, lng: float, near_m: float = 40.0):
+        """점을 포함하는 건물. 없으면 near_m 이내 최근접 건물.
+
+        POI 대표점이 건물 폴리곤 살짝 밖(주차장·마당 쪽)에 찍힌 사례가 많아
+        25m 로는 놓치는 시설이 있었다(#27, resolved_by=facility_centroid).
+        40m 로 완화 — 시설 부지 규모에서 엉뚱한 옆 건물로 붙을 위험은
+        '최근접' 선택이 흡수한다.
+        """
         if not self.loaded:
             return None
         try:
@@ -72,7 +78,7 @@ class BuildingIndex:
         if best is None:
             return None
         # 도 -> m 근사 (위도 37도 기준)
-        if best_d * 88000 <= 25.0:
+        if best_d * 88000 <= near_m:
             return best
         return None
 

--- a/route_service/engine/graph.py
+++ b/route_service/engine/graph.py
@@ -43,6 +43,29 @@ EDGE_DEFAULTS = {
     "geometry": None,
 }
 
+# 링크 이름 -> 보행 부적합 시설 재분류 (#27).
+# 차량용 지하차도(예: "일번가지하차도")는 OSM 태그상 highway=road + tunnel 이라
+# 기존 빌드에서 link_type="road" 로 들어와 휠체어 회피(avoid=underpass)를 그대로
+# 통과했다. 이미 배포된 그래프(pickle·DB 산출본)를 재빌드 없이 바로잡기 위해
+# 로드 시점에 이름으로 재분류한다. 재빌드 시점에는 sources/osm.py 의 태그 분류가
+# 같은 결과를 낸다.
+_NAME_RECLASS = (
+    (("지하차도", "지하도", "지하보도"), "underpass"),
+    (("육교", "고가교"), "overpass"),
+)
+# 이름 재분류를 허용하는 기존 타입 — 명시 조사된 타입(crossing·steps 등)은 건드리지 않는다.
+_NAME_RECLASS_FROM = ("road", "sidewalk", "unknown")
+
+
+def _reclass_by_name(link_type: str, link_name) -> str:
+    if link_type not in _NAME_RECLASS_FROM or not link_name:
+        return link_type
+    name = str(link_name)
+    for keywords, new_type in _NAME_RECLASS:
+        if any(k in name for k in keywords):
+            return new_type
+    return link_type
+
 
 def normalize_graph(G: nx.Graph) -> nx.Graph:
     """소스별 편차를 흡수해 표준 스키마로 맞춘다. 기존 인천 gpickle 도 그대로 수용."""
@@ -53,6 +76,7 @@ def normalize_graph(G: nx.Graph) -> nx.Graph:
             data.setdefault(k, default)
         if data["link_type"] not in LINK_TYPES:
             data["link_type"] = "unknown"
+        data["link_type"] = _reclass_by_name(data["link_type"], data.get("link_name"))
         try:
             data["length"] = float(data["length"])
         except (TypeError, ValueError):

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -13,13 +13,40 @@ import uuid
 
 import networkx as nx
 
-from .geo import haversine_m, path_length_m, point_segment_dist_m
+from .geo import bearing_deg, haversine_m, path_length_m, point_segment_dist_m, turn_angle
 from .graph import edge_coords
 from .profiles import Profile
+
+# 유턴 판정 각도 — steps.py 의 턴바이턴 유턴 기준(150도)과 동일해야
+# "안내에는 유턴으로 뜨는데 탐색은 못 잡는" 불일치가 안 생긴다.
+UTURN_ANGLE_DEG = 150.0
+UTURN_RETRY = 3
 
 
 class NoRouteError(Exception):
     pass
+
+
+def _uturn_edges(G, path) -> set:
+    """경로에서 유턴(150도 이상 회차)이 발생하는 지점의 앞뒤 링크 집합.
+
+    노드 기반 A* 는 회전 비용을 모른다. 그 결과 지하차도 진입로를 타고 들어갔다가
+    되돌아 나오는 식의 경로(#27, 일번가지하차도 583m + 유턴)가 최단으로 뽑힌다.
+    탐색 후 기하로 유턴을 검출해 해당 링크에 페널티를 주고 재탐색하는 방식으로 억제한다.
+    """
+    edges = set()
+    prev_out = None
+    prev_edge = None
+    for u, v in zip(path[:-1], path[1:]):
+        coords = edge_coords(G, u, v)
+        in_b = bearing_deg(coords[0][0], coords[0][1], coords[1][0], coords[1][1])
+        out_b = bearing_deg(coords[-2][0], coords[-2][1], coords[-1][0], coords[-1][1])
+        if prev_out is not None and abs(turn_angle(prev_out, in_b)) >= UTURN_ANGLE_DEG:
+            edges.add(prev_edge)
+            edges.add(frozenset((u, v)))
+        prev_out = out_b
+        prev_edge = frozenset((u, v))
+    return edges
 
 
 def edge_passable(data: dict, profile: Profile, max_slope_deg: float) -> bool:
@@ -159,6 +186,25 @@ def plan(store, start_node, goal_node, profile: Profile, alternatives: int = 1,
         raise NoRouteError("통행 가능한 경로를 찾지 못했습니다")
 
     applied = fallback["applied_max_slope_deg"]
+
+    # 유턴 억제 재탐색 — 유턴 없는 경로가 나오면 채택, 끝까지 없으면 유턴 최소 경로.
+    uturn_pen = set()
+    best_n, best_path = len(_uturn_edges(G, primary)), primary
+    for _ in range(UTURN_RETRY):
+        if best_n == 0:
+            break
+        uturn_pen |= _uturn_edges(G, best_path)
+        try:
+            cand = _astar(G, start_node, goal_node, profile, applied, uturn_pen)
+        except (nx.NetworkXNoPath, nx.NodeNotFound):
+            break
+        if cand == best_path:
+            break
+        n = len(_uturn_edges(G, cand))
+        if n < best_n:
+            best_n, best_path = n, cand
+    primary = best_path
+
     routes = [primary]
 
     # 대안 경로: 1안의 링크에 페널티를 주고 재탐색 (중복 경로는 버림)

--- a/route_service/engine/profiles.py
+++ b/route_service/engine/profiles.py
@@ -49,7 +49,9 @@ PROFILES = {
         speed_mps=0.7,
         slope_factor=0.30,
         avoid=("steps", "overpass", "underpass"),
-        penalize={"crossing": 1.2, "ramp": 1.1},
+        # road 가중: 보도(sidewalk)가 있는 우회로가 있으면 이면도로·차도 통행을
+        # 뒤로 미룬다. 하드 차단이 아니라 가중이므로 보도 미비 구간은 여전히 통행 가능.
+        penalize={"crossing": 1.2, "ramp": 1.1, "road": 1.25, "unknown": 1.1},
         min_width_m=0.9,
         requires_curb_cut=True,
     ),
@@ -60,7 +62,7 @@ PROFILES = {
         speed_mps=1.1,
         slope_factor=0.15,
         avoid=("steps", "overpass", "underpass"),
-        penalize={"crossing": 1.1},
+        penalize={"crossing": 1.1, "road": 1.2, "unknown": 1.1},
         min_width_m=0.9,
         requires_curb_cut=True,
     ),

--- a/route_service/engine/sources/osm.py
+++ b/route_service/engine/sources/osm.py
@@ -56,6 +56,10 @@ def classify_link(tags: dict) -> str:
             return "underpass"
         return "sidewalk"
     if hw in ("residential", "service", "unclassified", "tertiary", "secondary", "primary"):
+        # 차량 도로의 터널 = 지하차도. 기존에는 "road" 로 분류되어 휠체어 회피
+        # (avoid=underpass)를 통과했다 — 583m 지하차도 경유 안내의 원인(#27).
+        if tunnel and tunnel != "no":
+            return "underpass"
         return "road"
     return "unknown"
 

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -59,6 +59,31 @@ def _is_y(v) -> bool:
     return str(v).strip().upper() in ("Y", "TRUE", "1")
 
 
+# 시·군·구 행정단위 접미사. "안양" 처럼 접미사 없이 들어온 지역명은 이 접미사를 붙인
+# 변형("안양시"/"안양군"/"안양구")으로만 주소를 대조한다. 단순 부분일치는 전남 장흥군
+# "안양면" 같은 타지역 주소까지 끌어온다(#26).
+_SIGUNGU_SUFFIXES = ("시", "군", "구")
+
+
+def sigungu_variants(sigungu: str) -> list:
+    """지역명 -> 주소 대조용 행정단위 토큰 목록.
+
+    "안양"   -> ["안양시", "안양군", "안양구"]
+    "안양시" -> ["안양시"]  (이미 행정단위 접미사가 있으면 그대로)
+    """
+    s = (sigungu or "").strip()
+    if not s:
+        return []
+    if s.endswith(_SIGUNGU_SUFFIXES):
+        return [s]
+    return [s + suf for suf in _SIGUNGU_SUFFIXES]
+
+
+def _addr_in_sigungu(addr: str, variants: list) -> bool:
+    a = addr or ""
+    return any(v in a for v in variants)
+
+
 class PoiStore:
     def __init__(self, backend: str = "none", data_dir: str = "", dsn: str = ""):
         self.backend = backend
@@ -103,9 +128,25 @@ class PoiStore:
     def list_tour_spots(self, sigungu: str = "", bbox=None, limit: int = 50) -> list:
         if self.backend == "none":
             return []
+        variants = sigungu_variants(sigungu)
         if self.backend == "file":
             rows = self._load_file("tour_bf.json")
         else:
+            # 지역 필터는 주소의 시·군·구 토큰 정합으로만 판정한다.
+            # LIKE '%안양%' 방식은 주소 전체를 보기 때문에 전남 장흥군 "안양면" 소재
+            # POI(거리 307km)까지 포함시켰다(#26). title 대조도 같은 이유로 지역
+            # 필터에서 제외한다(이름 검색은 get_tour_spot 의 이름 폴백이 담당).
+            sg_clause = ""
+            params = {"limit": limit}
+            if variants:
+                ors = []
+                for i, v in enumerate(variants):
+                    ors.append(
+                        "COALESCE(address_road, '') LIKE '%%' || :sg{0} || '%%'"
+                        " OR COALESCE(address_detail, '') LIKE '%%' || :sg{0} || '%%'".format(i)
+                    )
+                    params["sg%d" % i] = v
+                sg_clause = "AND (%s)" % " OR ".join(ors)
             rows = self._query(
                 """
                 SELECT poi_id,
@@ -118,20 +159,14 @@ class PoiStore:
                  WHERE language_code = 'ko'
                    AND latitude IS NOT NULL AND longitude IS NOT NULL
                    AND COALESCE(detail_json->>'accessible_facilities', '') <> ''
-                   AND (:sigungu = ''
-                        OR COALESCE(address_road, '') LIKE '%%' || :sigungu || '%%'
-                        OR COALESCE(address_detail, '') LIKE '%%' || :sigungu || '%%'
-                        OR title LIKE '%%' || :sigungu || '%%')
+                   {sg}
                  LIMIT :limit
-                """,
-                {"sigungu": sigungu or "", "limit": limit},
+                """.format(sg=sg_clause),
+                params,
             )
         out = [self._normalize_tour(r) for r in rows]
-        if sigungu and self.backend == "file":
-            out = [
-                r for r in out
-                if sigungu in (r.get("addr") or "") or sigungu in (r.get("name") or "")
-            ]
+        if variants and self.backend == "file":
+            out = [r for r in out if _addr_in_sigungu(r.get("addr"), variants)]
         if bbox:
             min_lat, min_lng, max_lat, max_lng = bbox
             out = [

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -3,7 +3,7 @@
 
 백엔드 3종 (POI_BACKEND 환경변수)
   db   : 01-IITP-DABT-Database 읽기 전용 조회
-         poi_tour_bf_facility / poi_station_access_status /
+         mv_poi (무장애 관광지 정본) / poi_station_access_status /
          poi_station_wheelchair_lift / poi_facility_accessibility
   file : POI_DATA_DIR 아래 JSON (오프라인·개발·데모용)
   none : 빈 결과 (source="none") — 적재 전에도 서비스가 기동되도록
@@ -24,6 +24,26 @@ TOUR_FIELDS = [
     "wheelchair_rent_yn", "tactile_map_yn", "audio_guide_yn", "nursing_room_yn",
     "accessible_room_yn", "stroller_rent_yn",
 ]
+
+# mv_poi.detail_json.accessible_facilities 의 표기 -> TOUR_FIELDS 매핑 (2026-07-16 전수 실측)
+# 통합DB 는 시설을 한국어 문구로 담고 있어 기존 *_yn 필드 체계로 정규화한다.
+MVPOI_FACILITY_MAP = {
+    "장애인 전용 통로 있음": "toilet_yn",        # 화장실 접근 동선 — 대표 지표로 사용
+    "엘리베이터 있음": "elevator_yn",
+    "장애인 주차장 있음": "parking_yn",
+    "접근로 있음": "slope_yn",
+    "대중교통 이용 가능": "subway_yn",
+    "휠체어 대여 가능": "wheelchair_rent_yn",
+    "점자블록 있음": "tactile_map_yn",
+    "점자 홍보물 있음": "tactile_map_yn",
+    "유도안내설비 있음": "tactile_map_yn",
+    "오디오가이드 있음": "audio_guide_yn",
+    "안내요원 있음": "audio_guide_yn",
+    "수화안내 가능": "audio_guide_yn",
+    "자막 지원 가능": "audio_guide_yn",
+    "장애인 객실 있음": "accessible_room_yn",
+    "지체장애인 관람석 있음": "accessible_room_yn",
+}
 
 # 장애 유형 -> 필요한 편의시설 필드 (10-TripSense 매칭 로직과 동일한 사고)
 DISABILITY_REQUIREMENTS = {
@@ -88,19 +108,20 @@ class PoiStore:
         else:
             rows = self._query(
                 """
-                SELECT fclt_id AS poi_id,
-                       fclt_name AS name,
-                       COALESCE(addr_road, addr_jibun) AS addr,
+                SELECT poi_id,
+                       title AS name,
+                       COALESCE(address_road, address_detail) AS addr,
                        latitude, longitude,
-                       toilet_yn, elevator_yn, parking_yn, slope_yn,
-                       subway_yn, bus_stop_yn, wheelchair_rent_yn, tactile_map_yn,
-                       audio_guide_yn, nursing_room_yn, accessible_room_yn, stroller_rent_yn
-                  FROM poi_tour_bf_facility
-                 WHERE del_yn = 'N'
+                       detail_json->>'accessible_facilities' AS fac_text,
+                       search_filter_json->'search_filter'->>'tourist_type' AS tourist_type
+                  FROM mv_poi
+                 WHERE language_code = 'ko'
+                   AND latitude IS NOT NULL AND longitude IS NOT NULL
+                   AND COALESCE(detail_json->>'accessible_facilities', '') <> ''
                    AND (:sigungu = ''
-                        OR COALESCE(addr_road, '') LIKE '%%' || :sigungu || '%%'
-                        OR COALESCE(addr_jibun, '') LIKE '%%' || :sigungu || '%%'
-                        OR fclt_name LIKE '%%' || :sigungu || '%%')
+                        OR COALESCE(address_road, '') LIKE '%%' || :sigungu || '%%'
+                        OR COALESCE(address_detail, '') LIKE '%%' || :sigungu || '%%'
+                        OR title LIKE '%%' || :sigungu || '%%')
                  LIMIT :limit
                 """,
                 {"sigungu": sigungu or "", "limit": limit},
@@ -122,10 +143,24 @@ class PoiStore:
         return out[:limit]
 
     @staticmethod
+    def _facilities_from_text(text: str) -> dict:
+        """mv_poi 의 한국어 시설 문구 -> *_yn 불리언 맵."""
+        fac = {k: False for k in TOUR_FIELDS}
+        for part in (text or "").split(","):
+            key = MVPOI_FACILITY_MAP.get(part.strip())
+            if key:
+                fac[key] = True
+        return fac
+
+    @staticmethod
     def _normalize_tour(r: dict) -> dict:
         lat = r.get("latitude", r.get("lat"))
         lng = r.get("longitude", r.get("lng"))
         addr = r.get("addr") or r.get("addr_road") or r.get("addr_jibun")
+        if r.get("fac_text") is not None:
+            fac = PoiStore._facilities_from_text(r.get("fac_text"))
+        else:
+            fac = {k: _is_y(r.get(k)) for k in TOUR_FIELDS}
         return {
             "poi_id": str(r.get("poi_id") or r.get("fclt_id") or r.get("id") or ""),
             "type": "tour",
@@ -133,13 +168,27 @@ class PoiStore:
             "addr": addr,
             "lat": float(lat) if lat is not None else None,
             "lng": float(lng) if lng is not None else None,
-            "facilities": {k: _is_y(r.get(k)) for k in TOUR_FIELDS},
+            "facilities": fac,
             "entrance": r.get("entrance"),
         }
 
     def get_tour_spot(self, poi_id: str):
-        for r in self.list_tour_spots(limit=10000):
-            if r["poi_id"] == str(poi_id):
+        """ID 우선, 실패하면 이름으로도 찾는다.
+
+        12번 음성 도구는 사용자가 말한 관광지 '이름'을 그대로 넘기는 경우가 있어
+        ID 전용 조회는 404 를 낸다. 이름 폴백으로 실사용 실패를 막는다.
+        """
+        key = str(poi_id).strip()
+        rows = self.list_tour_spots(limit=10000)
+        for r in rows:
+            if r["poi_id"] == key:
+                return r
+        for r in rows:
+            if (r.get("name") or "").strip() == key:
+                return r
+        norm = key.replace(" ", "")
+        for r in rows:
+            if (r.get("name") or "").replace(" ", "") == norm:
                 return r
         return None
 
@@ -157,7 +206,9 @@ class PoiStore:
         return {"lat": spot["lat"], "lng": spot["lng"], "source": "facility_centroid"}
 
     def recommend_tour(self, disabilities: list, sigungu: str = "안양",
-                       match_mode: str = "all", topk: int = 10) -> list:
+                       match_mode: str = "all", topk: int = 10,
+                       origin_lat: float = None, origin_lng: float = None,
+                       offset: int = 0) -> list:
         """장애 유형별 무장애 관광지 랭킹.
 
         10-TripSense 의 filter_and_rank 와 동일한 판단 기준(요구 편의시설 충족 여부)을
@@ -190,8 +241,24 @@ class PoiStore:
             item["matched"] = [f for f in TOUR_FIELDS if fac.get(f)]
             scored.append(item)
 
-        scored.sort(key=lambda x: (-x["score"], x["name"] or ""))
-        return scored[:topk]
+        # 출발지가 주어지면 거리 오름차순 — 반경 제한 없이 전체를 이어서 페이징한다.
+        # (offset 이 있어도 정렬 기준은 동일하므로 목록 순서가 뒤섞이지 않는다)
+        if origin_lat is not None and origin_lng is not None:
+            for it in scored:
+                if it["lat"] is None or it["lng"] is None:
+                    it["distance_m"] = None
+                    continue
+                it["distance_m"] = round(
+                    haversine_m(origin_lat, origin_lng, it["lat"], it["lng"]), 1
+                )
+            scored.sort(key=lambda x: (x["distance_m"] is None,
+                                       x["distance_m"] if x["distance_m"] is not None else 0,
+                                       x["name"] or ""))
+        else:
+            scored.sort(key=lambda x: (-x["score"], x["name"] or ""))
+
+        start = max(0, int(offset or 0))
+        return scored[start:start + topk]
 
     # ---------- 대중교통 접근점 ----------
     def list_transit_access(self, lat: float, lng: float, radius_m: float = 800,

--- a/tests/test_route_quality.py
+++ b/tests/test_route_quality.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""경로 품질 회귀 테스트 (#26, #27).
+
+- #26: sigungu 부분일치가 타지역 '안양면'까지 포함하던 문제
+- #27: 지하차도(road 분류) 경유·유턴 경로가 최단으로 뽑히던 문제
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import networkx as nx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from route_service.engine.graph import NetworkStore  # noqa: E402
+from route_service.engine.planner import _uturn_edges, plan  # noqa: E402
+from route_service.engine.profiles import get_profile  # noqa: E402
+from route_service.poi.store import PoiStore, sigungu_variants  # noqa: E402
+
+
+# ---------- #26 sigungu 정합 매칭 ----------
+
+def test_sigungu_variants_expand_bare_name():
+    assert sigungu_variants("안양") == ["안양시", "안양군", "안양구"]
+
+
+def test_sigungu_variants_keep_administrative_suffix():
+    assert sigungu_variants("안양시") == ["안양시"]
+    assert sigungu_variants("만안구") == ["만안구"]
+    assert sigungu_variants("") == []
+
+
+def test_tour_filter_excludes_other_region_myeon(tmp_path):
+    """전남 장흥군 '안양면' 소재 POI 가 sigungu='안양' 조회에 포함되면 안 된다."""
+    rows = [
+        {
+            "poi_id": "1", "name": "안양예술공원",
+            "addr": "경기도 안양시 만안구 예술공원로 131",
+            "latitude": 37.4093, "longitude": 126.9316,
+            "elevator_yn": "Y",
+        },
+        {
+            "poi_id": "4318", "name": "수문해수욕장",
+            "addr": "전라남도 장흥군 안양면 수문리",
+            "latitude": 34.5583, "longitude": 126.9843,
+            "elevator_yn": "Y",
+        },
+    ]
+    (tmp_path / "tour_bf.json").write_text(
+        json.dumps(rows, ensure_ascii=False), encoding="utf-8"
+    )
+    store = PoiStore(backend="file", data_dir=str(tmp_path))
+    out = store.list_tour_spots(sigungu="안양")
+    ids = {r["poi_id"] for r in out}
+    assert ids == {"1"}
+
+
+# ---------- #27 링크 이름 기반 재분류 ----------
+
+def _one_edge_graph(link_type: str, link_name: str) -> nx.Graph:
+    G = nx.Graph()
+    G.add_node("A", lat=37.39, lon=126.95, node_type="unknown")
+    G.add_node("B", lat=37.39, lon=126.951, node_type="unknown")
+    G.add_edge("A", "B", length=90.0, slope=0.0, link_type=link_type,
+               width=None, curb_cut=None, surface=None,
+               link_name=link_name, geometry=None)
+    return G
+
+
+@pytest.mark.parametrize("lt,name,expected", [
+    ("road", "일번가지하차도", "underpass"),
+    ("sidewalk", "만안지하도", "underpass"),
+    ("road", "안양육교", "overpass"),
+    ("unknown", "비산고가교", "overpass"),
+    ("road", "예시로", "road"),               # 일반 도로는 그대로
+    ("crossing", "중앙지하차도앞", "crossing"),  # 명시 조사 타입은 보존
+])
+def test_normalize_reclassifies_underpass_by_name(lt, name, expected):
+    s = NetworkStore()
+    s.load_graph_object(_one_edge_graph(lt, name))
+    assert s.graph["A"]["B"]["link_type"] == expected
+
+
+def test_wheelchair_avoids_named_underpass_link():
+    """이름으로 재분류된 지하차도 링크는 휠체어 경로에서 하드 차단된다."""
+    G = nx.Graph()
+    G.add_node("A", lat=37.3900, lon=126.9500, node_type="unknown")
+    G.add_node("B", lat=37.3900, lon=126.9520, node_type="unknown")
+    G.add_node("C", lat=37.3910, lon=126.9510, node_type="unknown")
+    # 지름길: 차량 지하차도 (기존 빌드에서 road 로 들어온 케이스)
+    G.add_edge("A", "B", length=100.0, slope=0.0, link_type="road",
+               width=None, curb_cut=None, surface=None,
+               link_name="일번가지하차도", geometry=None)
+    # 우회로: 보도
+    G.add_edge("A", "C", length=120.0, slope=0.0, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    G.add_edge("C", "B", length=120.0, slope=0.0, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    s = NetworkStore()
+    s.load_graph_object(G)
+    res = plan(s, "A", "B", get_profile("wheelchair_manual"))
+    assert res["routes"][0]["path"] == ["A", "C", "B"]
+
+
+# ---------- #27 유턴 억제 ----------
+
+def _uturn_graph() -> NetworkStore:
+    """유턴 지름길 vs 유턴 없는 우회로.
+
+        S ==(60m)== B     (동쪽으로 갔다가)
+        C ==(60m)== T     (되돌아 나오는 평행로 — B 에서 유턴)
+        S --(110m)-- D --(110m)-- T   (북쪽 우회, 유턴 없음)
+    """
+    G = nx.Graph()
+    G.add_node("S", lat=37.39000, lon=126.95000, node_type="unknown")
+    G.add_node("B", lat=37.39000, lon=126.95200, node_type="unknown")
+    G.add_node("C", lat=37.39005, lon=126.95000, node_type="unknown")
+    G.add_node("T", lat=37.39010, lon=126.94900, node_type="unknown")
+    G.add_node("D", lat=37.39060, lon=126.95000, node_type="unknown")
+    common = dict(slope=0.0, link_type="sidewalk", width=2.0, curb_cut=True,
+                  surface=None, link_name=None, geometry=None)
+    G.add_edge("S", "B", length=60.0, **common)   # 동진
+    G.add_edge("B", "C", length=60.0, **common)   # 서진 (S-B 와 역방향 = 유턴)
+    G.add_edge("C", "T", length=60.0, **common)
+    G.add_edge("S", "D", length=110.0, **common)
+    G.add_edge("D", "T", length=110.0, **common)
+    s = NetworkStore()
+    s.load_graph_object(G)
+    return s
+
+
+def test_uturn_edges_detected_on_switchback():
+    s = _uturn_graph()
+    edges = _uturn_edges(s.graph, ["S", "B", "C", "T"])
+    assert frozenset(("S", "B")) in edges
+    assert frozenset(("B", "C")) in edges
+
+
+def test_plan_prefers_route_without_uturn():
+    """길이상 최단(180m)이라도 유턴 경로 대신 유턴 없는 220m 우회로를 채택한다."""
+    s = _uturn_graph()
+    res = plan(s, "S", "T", get_profile("wheelchair_manual"))
+    path = res["routes"][0]["path"]
+    assert path == ["S", "D", "T"]
+    assert len(_uturn_edges(s.graph, path)) == 0


### PR DESCRIPTION
## 릴리즈 요약

`main` **v1.8.0** → **v1.10.0**. `subproject` 누적 작업 PR 2건을 main 으로 가져갑니다.

축은 두 가지입니다. 무장애 관광 POI 소스를 통합DB(mv_poi)로 일원화하고 거리순 페이징을 갖췄으며(v1.9.0), 실사용 검증에서 나온 경로 품질 결함 — 타지역 '안양면' 오매칭, 차량 지하차도 경유·유턴, 건물 중심 도착 — 을 정리했습니다(v1.10.0).

### 주요 변경

**v1.9.0 — POI 소스 일원화**
- 무장애 관광 POI 를 mv_poi(통합DB) 단일 소스로 전환
- 추천 목록 거리순 offset 페이징

**v1.10.0 — 경로 품질**
- 지역 필터를 시·군·구 행정단위 토큰 정합으로 교체 — 전남 장흥군 '안양면' 소재 POI(거리 307km)가 '안양' 조회에 섞이던 문제 해소
- 차량 지하차도(`highway=road + tunnel`) 회피 — 그래프 로드 시점 링크 이름 재분류로 기배포 그래프에도 즉시 적용, 재빌드용 태그 분류 정합
- 유턴(150도 이상 회차) 검출·페널티 재탐색, 휠체어 프로필 보도 우선 가중
- 건물 접근점 탐색 반경 25m → 40m

## 포함된 작업 PR

| PR | 버전 | 내용 |
|---|---|---|
| #25 | v1.9.0 | 무장애 POI 소스 mv_poi 일원화 + 추천 목록 거리순 offset 페이징 |
| #28 | v1.10.0 | 지역 필터 시군구 정합 매칭 + 지하차도 회피·유턴 억제·접근점 보강 |

## 해결된 이슈

- Closes #24
- Closes #26

※ #27 은 3건 중 2건(지하차도·접근점)을 본 릴리즈에서 반영, crossing 태깅은 안양시청 횡단보도 좌표본 수령 후 별도 반영 예정이라 open 유지.

## 검증

- `README.md` 레포 태그 **v1.10.0** 동기화 완료
- pytest 46건 통과 (신규 회귀 `tests/test_route_quality.py` 8건 포함)
- 검증 서버 배포 검증: 서버측 sha256 6/6 일치, `/health` ok, 재현 케이스(안양역→POI 17245) 유턴 0·지하차도 미경유 확인, 추천 조회 25건 전부 안양시 소재(타지역 0건)