### PR TITLE
v1.11.0 - /transit/access-points 에 버스 정류장 반환 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.10.0 |
+| 02-IITP-DABT-Route | v1.11.0 |
 
 ## 구조
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.6.0"
+__version__ = "1.11.0"

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 
 from ..engine.geo import haversine_m
@@ -305,7 +306,7 @@ class PoiStore:
           로 프론트/클라이언트가 확인해야 한다. 여기서는 위치·노선 정보만 제공한다.
         """
         stations = self._stations()
-        stops = self._stops()
+        stops = self._stops(lat=lat, lng=lng, radius_m=radius_m)
         needs_elevator = profile_id.startswith("wheelchair")
 
         out = []
@@ -336,12 +337,16 @@ class PoiStore:
             d = haversine_m(lat, lng, s["lat"], s["lng"])
             if d > radius_m:
                 continue
+            warnings = ["저상버스 여부는 실시간 도착정보로 확인하세요."]
+            if s.get("center_yn"):
+                # 중앙차로 정류소는 승차장이 도로 한가운데 있어 횡단이 선행된다.
+                warnings.append("중앙차로 정류소입니다. 승차장까지 횡단이 필요합니다.")
             item = dict(s)
             item.update({
                 "type": "transit_stop",
                 "dist_m": round(d),
                 "accessible": True,
-                "warnings": ["저상버스 여부는 실시간 도착정보로 확인하세요."],
+                "warnings": warnings,
             })
             out.append(item)
 
@@ -378,21 +383,65 @@ class PoiStore:
             })
         return norm
 
-    def _stops(self) -> list:
-        """버스 정류장 — 현재 01 DB 에 정류장 좌표 테이블이 없어 file 백엔드만 지원."""
-        if self.backend != "file":
+    def _stops(self, lat=None, lng=None, radius_m=None, poi_id: str = "") -> list:
+        """버스 정류장.
+
+        db 백엔드는 01 의 ``tran_bus_station_info`` / ``tran_bus_route_station`` 을 읽는다
+        (08 이 GBIS 경유정류소 목록조회로 적재). 안양 연관 노선의 전 경유지가 들어와
+        전국 범위가 되므로, 반경이 주어지면 **bbox 로 먼저 좁혀** 전수 로드를 피한다.
+
+        저상버스 정차 여부는 정적 DB 에 없다 — 실시간 도착정보(GBIS lowPlate)로
+        클라이언트가 확인한다. 여기서는 위치·정류소번호·경유노선·중앙차로 여부만 제공한다.
+        """
+        if self.backend == "none":
             return []
-        rows = self._load_file("transit_stops.json")
+        if self.backend == "file":
+            rows = self._load_file("transit_stops.json")
+        else:
+            where = ["COALESCE(s.del_yn, 'N') = 'N'",
+                     "s.latitude IS NOT NULL", "s.longitude IS NOT NULL"]
+            params = {}
+            if poi_id:
+                where.append("s.station_id::text = :poi_id")
+                params["poi_id"] = str(poi_id)
+            elif lat is not None and lng is not None and radius_m:
+                d_lat = float(radius_m) / 111320.0
+                d_lng = d_lat / max(math.cos(math.radians(lat)), 0.01)
+                where.append("s.latitude BETWEEN :min_lat AND :max_lat")
+                where.append("s.longitude BETWEEN :min_lng AND :max_lng")
+                params.update({"min_lat": lat - d_lat, "max_lat": lat + d_lat,
+                               "min_lng": lng - d_lng, "max_lng": lng + d_lng})
+            rows = self._query(
+                """
+                SELECT s.station_id AS poi_id, s.station_name AS name,
+                       s.latitude, s.longitude, s.mobile_no, s.center_yn,
+                       (SELECT string_agg(DISTINCT r.route_name, ',')
+                          FROM tran_bus_route_station rs
+                          JOIN tran_bus_route_info r ON r.route_id = rs.route_id
+                         WHERE rs.station_id = s.station_id
+                           AND COALESCE(rs.del_yn, 'N') = 'N'
+                           AND COALESCE(r.del_yn, 'N') = 'N') AS route_names
+                  FROM tran_bus_station_info s
+                 WHERE """ + " AND ".join(where),
+                params,
+            )
         norm = []
         for r in rows:
-            lat = r.get("lat", r.get("latitude"))
-            lng = r.get("lng", r.get("longitude"))
+            lat_v = r.get("lat", r.get("latitude"))
+            lng_v = r.get("lng", r.get("longitude"))
+            routes = r.get("routes")
+            if routes is None:
+                raw = str(r.get("route_names") or "")
+                routes = sorted({x for x in raw.split(",") if x})
+            mobile_no = r.get("mobile_no")
             norm.append({
                 "poi_id": str(r.get("poi_id") or r.get("station_id") or ""),
                 "name": r.get("name") or r.get("station_name"),
-                "lat": float(lat) if lat is not None else None,
-                "lng": float(lng) if lng is not None else None,
-                "routes": r.get("routes") or [],
+                "lat": float(lat_v) if lat_v is not None else None,
+                "lng": float(lng_v) if lng_v is not None else None,
+                "mobile_no": (str(mobile_no).strip() or None) if mobile_no else None,
+                "center_yn": _is_y(r.get("center_yn")),
+                "routes": routes,
             })
         return norm
 
@@ -400,7 +449,8 @@ class PoiStore:
         """목적지 유형별 좌표 해석. tour 는 무장애 출입구 우선."""
         if dest_type == "tour":
             return self.get_entrance(poi_id)
-        pool = self._stations() if dest_type == "transit_station" else self._stops()
+        pool = (self._stations() if dest_type == "transit_station"
+                else self._stops(poi_id=poi_id))
         for s in pool:
             if s["poi_id"] == str(poi_id) and s["lat"] is not None:
                 return {"lat": s["lat"], "lng": s["lng"], "source": dest_type}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,19 @@ def client(tmp_path, monkeypatch):
         encoding="utf-8",
     )
 
+    (poi_dir / "transit_stops.json").write_text(
+        json.dumps(
+            [
+                {"poi_id": "B1", "name": "테스트정류장", "lat": 37.3901,
+                 "lng": 126.9503, "mobile_no": "09999", "routes": ["2", "11"]},
+                {"poi_id": "B2", "name": "중앙차로정류장", "lat": 37.3902,
+                 "lng": 126.9504, "mobile_no": "09998", "center_yn": "Y", "routes": ["1"]},
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
     monkeypatch.setenv("NETWORK_PATH", str(net))
     monkeypatch.setenv("NETWORK_VERSION", "test-1")
     monkeypatch.setenv("POI_BACKEND", "file")
@@ -175,6 +188,51 @@ def test_transit_access_points_flag_lift_only_station(client):
     by_id = {i["poi_id"]: i for i in body["items"]}
     assert by_id["S1"]["warnings"] == []            # 엘리베이터 보유
     assert by_id["S2"]["warnings"]                  # 리프트만 -> 경고
+
+
+def test_transit_access_points_include_bus_stops(client):
+    """버스 정류장도 접근점으로 반환되어야 한다(실증 버스 구간 안내의 전제)."""
+    body = client.get(
+        "/transit/access-points",
+        params={"lat": 37.3900, "lng": 126.9500, "radius_m": 800,
+                "profile": "wheelchair_manual"},
+    ).json()
+    by_id = {i["poi_id"]: i for i in body["items"]}
+    assert {"S1", "S2", "B1", "B2"} <= set(by_id)
+    stop = by_id["B1"]
+    assert stop["type"] == "transit_stop"
+    assert stop["mobile_no"] == "09999"
+    assert stop["routes"] == ["2", "11"]
+    assert any("저상버스" in w for w in stop["warnings"])
+
+
+def test_transit_access_points_warn_center_lane_stop(client):
+    """중앙차로 정류소는 승차장까지 횡단이 선행되므로 별도 경고가 필요하다."""
+    body = client.get(
+        "/transit/access-points",
+        params={"lat": 37.3900, "lng": 126.9500, "radius_m": 800},
+    ).json()
+    by_id = {i["poi_id"]: i for i in body["items"]}
+    assert by_id["B2"]["center_yn"] is True
+    assert any("횡단" in w for w in by_id["B2"]["warnings"])
+    assert by_id["B1"]["center_yn"] is False
+    assert not any("횡단" in w for w in by_id["B1"]["warnings"])
+
+
+def test_transit_access_points_respect_radius(client):
+    """반경 밖 정류장·역은 제외되어야 한다."""
+    far = client.get(
+        "/transit/access-points",
+        params={"lat": 37.5000, "lng": 127.1000, "radius_m": 800},
+    ).json()
+    assert far["count"] == 0
+
+    near = client.get(
+        "/transit/access-points",
+        params={"lat": 37.3900, "lng": 126.9500, "radius_m": 800},
+    ).json()
+    assert near["count"] == 4
+    assert all(i["dist_m"] <= 800 for i in near["items"])
 
 
 def test_entrance_endpoint_reports_source(client):

--- a/tests/test_poi_store.py
+++ b/tests/test_poi_store.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""PoiStore 버스 정류장 조회 — 이슈 #31.
+
+db 백엔드는 전국 범위 정류장을 담으므로, 반경 조회가 bbox 로 선필터되는지와
+행 정규화가 계약대로인지 DB 없이 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from route_service.poi.store import PoiStore  # noqa: E402
+
+
+class _RecordingStore(PoiStore):
+    """_query 를 가로채 SQL·파라미터를 기록하고 고정 행을 돌려준다."""
+
+    def __init__(self, rows):
+        super().__init__(backend="db", dsn="postgresql+psycopg2://x/y")
+        self._rows = rows
+        self.last_sql = None
+        self.last_params = None
+
+    def _query(self, sql, params):
+        self.last_sql = sql
+        self.last_params = params
+        return self._rows
+
+
+ROW = {
+    "poi_id": 208000363,
+    "name": "안양박물관.김중업건축박물관",
+    "latitude": 37.4175833,
+    "longitude": 126.91805,
+    "mobile_no": " 09327",
+    "center_yn": "N",
+    "route_names": "2,11,2",
+}
+
+
+def test_stops_normalizes_db_row():
+    store = _RecordingStore([ROW])
+    out = store._stops(lat=37.4176, lng=126.9180, radius_m=500)
+    assert len(out) == 1
+    s = out[0]
+    assert s["poi_id"] == "208000363"
+    assert s["lat"] == pytest.approx(37.4175833)
+    assert s["lng"] == pytest.approx(126.91805)
+    # 응답의 정류소번호에는 선행 공백이 붙어 온다 — 저장·반환 전에 제거되어야 한다
+    assert s["mobile_no"] == "09327"
+    assert s["center_yn"] is False
+    # 경유 노선은 중복 제거 후 정렬
+    assert s["routes"] == ["11", "2"]
+
+
+def test_stops_applies_bbox_prefilter():
+    store = _RecordingStore([])
+    store._stops(lat=37.4, lng=126.92, radius_m=1000)
+    assert "s.latitude BETWEEN" in store.last_sql
+    assert "s.longitude BETWEEN" in store.last_sql
+    p = store.last_params
+    assert p["min_lat"] < 37.4 < p["max_lat"]
+    assert p["min_lng"] < 126.92 < p["max_lng"]
+    # 위도 1도가 경도 1도보다 길므로 경도 폭이 더 넓어야 한다
+    assert (p["max_lng"] - p["min_lng"]) > (p["max_lat"] - p["min_lat"])
+
+
+def test_stops_single_lookup_uses_poi_id_filter():
+    """목적지 해석은 전체 목록을 받아 순회하지 않고 단건으로 조회한다."""
+    store = _RecordingStore([ROW])
+    store._stops(poi_id="208000363")
+    assert "s.station_id::text = :poi_id" in store.last_sql
+    assert store.last_params["poi_id"] == "208000363"
+    assert "BETWEEN" not in store.last_sql
+
+
+def test_stops_center_lane_flag_is_parsed():
+    store = _RecordingStore([dict(ROW, center_yn="Y")])
+    assert store._stops(poi_id="1")[0]["center_yn"] is True
+
+
+def test_stops_none_backend_returns_empty():
+    assert PoiStore(backend="none")._stops(lat=37.4, lng=126.9, radius_m=500) == []


### PR DESCRIPTION
## 변경 내용

01 v1.2.0 · 08 v1.9.0 으로 통합DB에 정류장 3,496건(안양 관내 759건) · 노선-정류장 8,938건이 적재되었으나, `/transit/access-points` 는 여전히 지하철역만 반환하였다. `poi/store.py` 의 `_stops()` 가 file 백엔드만 지원했기 때문이다.

### poi/store.py
- `_stops()` 에 **db 백엔드 분기 추가** — `tran_bus_station_info` 조회 + `tran_bus_route_station`·`tran_bus_route_info` 조인으로 경유 노선번호 동반 반환
- **bbox 선필터** — 안양 연관 노선의 전 경유지가 적재되어 사실상 전국 범위이므로, 반경이 주어지면 위경도 bbox 로 먼저 좁혀 조회한다(전수 로드 방지). 위도 1도와 경도 1도의 길이 차이를 `cos(lat)` 로 보정
- 응답에 `mobile_no`(정류소번호, 선행 공백 제거)와 `center_yn`(중앙차로 여부) 추가
- `resolve_destination` 의 정류장 해석을 **단건 조회**로 변경 — 기존에는 전체 목록을 받아 순회하였다

### list_transit_access
- **중앙차로 정류소 경고 추가** — 승차장이 도로 한가운데 있어 횡단이 선행되므로, 교통약자에게는 접근 동선이 달라진다

### 버전 표기 정정
`route_service/__init__.py` 의 `__version__` 이 **v1.6.0 에서 멈춰 있었다.** README 표기는 v1.10.0 인데 `/health` 와 OpenAPI 가 계속 1.6.0 을 보고하여 배포본 확인이 불가능했다. v1.11.0 으로 맞추고 README 도 갱신하였다.

## 테스트 방법

`python3 -m pytest tests/ -q` — **54건 전부 통과** (신규 8건)

신규 테스트:
- `tests/test_api.py` — 버스 정류장 반환, 중앙차로 경고 부여/미부여, 반경 밖 제외
- `tests/test_poi_store.py` — db 백엔드 행 정규화(정류소번호 공백 제거·경유노선 중복 제거·좌표), bbox 선필터 파라미터 검증(경도 폭 > 위도 폭), 단건 조회 시 bbox 미적용, 중앙차로 플래그 파싱, none 백엔드 빈 목록

DB 없이 `_query` 를 가로채는 방식이라 실제 DB 연결 없이도 계약을 검증한다.

## 참고

저상버스 정차 여부는 이번에도 정적 DB 에 넣지 않는다. 실시간 도착정보(GBIS `lowPlate`)로 클라이언트가 판별하는 기존 역할 분담을 유지하며, 응답 경고 문구로 안내한다.

Closes #31