### PR TITLE
v1.12.0 - 멀티모달 후보 실계산 평가 폭 보정 (4→8)

### DIFF
--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -412,7 +412,7 @@ def _plan_multimodal(origin_lat, origin_lng, dest: Destination, profile_id: str,
     # 근사 스코어 순 상위 후보를 전부 실계산해 비교한다 — 도보 근사(직선×배율)와
     # 실제 휠체어 경로(계단·경사·단절 우회)의 괴리로 1순위가 최악일 수 있다(리뷰 #2).
     built_cands, last_err = [], None
-    for cand in cands[:4]:
+    for cand in cands[:8]:      # 근사-실계산 괴리 보정 폭 — 도보 leg 계산은 저렴하다
         try:
             built = []
             for part in cand["parts"]:


### PR DESCRIPTION
#36 후속. 실서버 검증에서 근사 스코어 상위 4개 컷 때문에 실증 구간 3 의 최적 조합(안양역 환승)이 실계산 비교에 진입하지 못하고 장도보(2.5km) 후보가 채택되는 사례 확인 — 평가 폭을 8로 확대. 도보 leg 계산 비용은 낮아 지연 영향 미미. 재검증: 김중업→안양아트센터 walk_bus_subway 가 마을버스2→안양역(보행망 단절 경고 포함)→1호선→명학 조합으로 반환됨(총 58분). 전체 테스트 71건 통과.