### PR TITLE
v1.13.0 - 노드 부착 횡단보도 안내 계층 (crossing_point 스텝·crossing_point_cnt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.11.1 |
+| 02-IITP-DABT-Route | v1.13.0 |
 
 ## 구조
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -485,6 +485,7 @@ def _plan_multimodal(origin_lat, origin_lng, dest: Destination, profile_id: str,
         "max_slope_deg": max((l["summary"]["max_slope_deg"] for l in walk_legs), default=0),
         "stairs_cnt": sum(l["summary"]["stairs_cnt"] for l in walk_legs),
         "crossing_cnt": sum(l["summary"]["crossing_cnt"] for l in walk_legs),
+        "crossing_point_cnt": sum(l["summary"].get("crossing_point_cnt", 0) for l in walk_legs),
         "transit": {
             "bus_cnt": sum(1 for l in transit_legs if l["kind"] == "bus"),
             "subway_cnt": sum(1 for l in transit_legs if l["kind"] == "subway"),

--- a/route_service/api/schemas.py
+++ b/route_service/api/schemas.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
-"""요청·응답 스키마."""
+"""요청·응답 스키마.
+
+응답 본문은 main.py 에서 dict 로 조립한다. v1.13.0 추가 필드(하위 호환, 추가 전용):
+  - routes[].summary.crossing_point_cnt : 경로 노드에 지점 부착된 횡단보도 수
+    (기존 crossing_cnt = crossing 링크 수 — 의미 불변)
+  - routes[].steps[].maneuver == "crossing_point" : 노드 부착 횡단보도 안내 스텝
+    (distance_m 0, crosswalk_cnt 포함. 턱낮춤 False=경고 / None="턱낮춤 미상")
+"""
 from __future__ import annotations
 
 from typing import List, Optional

--- a/route_service/engine/graph.py
+++ b/route_service/engine/graph.py
@@ -6,16 +6,26 @@
 node attrs:
     lat, lon            : WGS84
     node_type           : intersection | crossing | entrance | stop | station | unknown
+    -- 이하 안양시 횡단보도 지점 부착 (apply_city_crosswalks.py [3]단계, 없으면 미부착) --
+    crosswalk_cnt       (int)        : 이 노드에 부착된 횡단보도 개수 (안내 전용 계층)
+    cw_mgmt_nos         (list[str])  : 부착분 관리번호 목록 (mv_crosswalk.mgmt_no)
+    cw_curb_cut         (bool|None)  : 부착분 턱낮춤 AND 집계. **None = 미상(없음 아님)**
+    cw_tactile_paving   (bool|None)  : 부착분 점자블록 AND 집계. None = 미상
 
 edge attrs:
     length      (float) : 링크 연장(m)
     slope       (float) : 평균 종단경사(도). DEM 미적용 시 0.0
     link_type   (str)   : sidewalk | road | crossing | steps | overpass | underpass | ramp | elevator | unknown
     width       (float|None) : 유효 보도폭(m)
-    curb_cut    (bool|None)  : 턱낮춤 여부(횡단보도 접속부)
+    curb_cut    (bool|None)  : 턱낮춤 여부(횡단보도 접속부). **None = 미상 — False 일 때만 차단**
+    tactile_paving (bool|None) : 점자블록 유무. None = 미상
     surface     (str|None)
     link_name   (str|None)
     geometry    (list[(lat, lon)]|None) : 실제 선형. 없으면 노드 직선으로 대체
+    -- 이하 안양시 횡단보도 원천 전이 (apply_city_crosswalks.py [1]·[2]단계, 선택) --
+    cw_length_m (float) : 횡단보도길이(횡단 거리) 원천값
+    cw_mgmt_no  (str)   : 매칭된 관리번호 (mv_crosswalk.mgmt_no)
+    attr_source (str)   : 속성 출처 (city_cw2026 | topo1k | ...)
 """
 from __future__ import annotations
 
@@ -38,6 +48,7 @@ EDGE_DEFAULTS = {
     "link_type": "unknown",
     "width": None,
     "curb_cut": None,
+    "tactile_paving": None,
     "surface": None,
     "link_name": None,
     "geometry": None,

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -108,6 +108,16 @@ def _summarize(G, path, profile, slope_coverage: float = 1.0) -> dict:
             warnings.append(
                 "권장 경사(%.1f도)를 넘는 구간이 포함되어 있습니다" % profile.max_slope_deg
             )
+    # 노드 지점 부착 횡단보도(안내 전용 계층) — crossing 링크와 별개로 집계한다.
+    # 기존 crossing_cnt(= crossing 링크 수)는 클라이언트 계약이 있으므로 의미를 바꾸지 않는다.
+    cw_points = 0
+    for n in path:
+        c = int(G.nodes[n].get("crosswalk_cnt") or 0)
+        if c:
+            cw_points += c
+            if G.nodes[n].get("cw_curb_cut") is False:
+                warnings.append("턱낮춤 없는 횡단보도 구간이 있습니다")
+
     mean_slope = sum(slopes) / len(slopes) if slopes else 0.0
     max_slope = max(slopes) if slopes else 0.0
     duration = dist / profile.speed_mps if profile.speed_mps else 0.0
@@ -130,6 +140,7 @@ def _summarize(G, path, profile, slope_coverage: float = 1.0) -> dict:
         "max_slope_deg": round(max_slope, 2),
         "stairs_cnt": counts["steps"],
         "crossing_cnt": counts["crossing"],
+        "crossing_point_cnt": cw_points,
         "elevator_cnt": counts["elevator"],
         "ramp_cnt": counts["ramp"],
         "accessibility_score": round(score, 2),

--- a/route_service/engine/steps.py
+++ b/route_service/engine/steps.py
@@ -26,6 +26,7 @@ MANEUVER_LABEL = {
     "sharp_right": "급우회전",
     "uturn": "유턴",
     "crossing": "횡단보도",
+    "crossing_point": "횡단보도",
     "elevator": "승강기",
     "ramp": "경사로",
     "steps": "계단",
@@ -63,6 +64,56 @@ def _edge_warnings(data: dict, profile: Profile) -> list:
     if profile.min_width_m and w is not None and w < profile.min_width_m:
         out.append("보도 폭 %.1fm (좁음)" % w)
     return out
+
+
+def _node_crosswalk_step(G, node, position: str = "mid") -> dict | None:
+    """노드에 지점 부착된 횡단보도의 안내 스텝(안내 전용 계층).
+
+    안양시 원천 횡단보도 2,728건 중 다수는 crossing 링크가 아니라 최근접 노드에
+    지점 메타로 부착돼 있다(apply_city_crosswalks.py [3]단계 -> 노드 crosswalk_cnt).
+    경로가 그 노드를 지나면 횡단 안내를 내보낸다. 위상(경로·거리·비용)에는 일절
+    관여하지 않으므로 경로 회귀 위험이 없다.
+
+    position: mid(경로 중간 — 횡단 지시) | start·end(출발·도착 지점 — 정보형 안내.
+    실제 횡단 여부를 단정할 수 없어 지시형 대신 존재를 알린다).
+
+    cw_curb_cut / cw_tactile_paving 의 None 은 "없음"이 아니라 **미상**이다
+    (원천 기재율 4.4%). False 일 때만 "없음" 경고, None 은 "턱낮춤 미상" 표기.
+    """
+    attrs = G.nodes[node]
+    cnt = int(attrs.get("crosswalk_cnt") or 0)
+    if cnt <= 0:
+        return None
+    warnings = []
+    curb = attrs.get("cw_curb_cut")
+    if curb is False:
+        warnings.append("턱낮춤 없음")
+    elif curb is None:
+        warnings.append("턱낮춤 미상")
+    if attrs.get("cw_tactile_paving") is False:
+        warnings.append("점자블록 없음")
+    many = "" if cnt == 1 else " %d개" % cnt
+    if position == "start":
+        base = "출발 지점에 횡단보도%s가 있습니다." % many
+    elif position == "end":
+        base = "도착 지점에 횡단보도%s가 있습니다." % many
+    elif cnt == 1:
+        base = "횡단보도가 있습니다. 횡단보도를 건너세요."
+    else:
+        base = "횡단보도 %d개가 있는 지점입니다. 횡단보도를 건너세요." % cnt
+    if warnings:
+        base += " (%s)" % ", ".join(warnings)
+    return {
+        "maneuver": "crossing_point",
+        "instruction": base,
+        "distance_m": 0,
+        "duration_sec": 0,
+        "coord": [round(float(attrs["lat"]), 7), round(float(attrs["lon"]), 7)],
+        "link_type": None,
+        "link_name": None,
+        "warnings": warnings,
+        "crosswalk_cnt": cnt,
+    }
 
 
 def _josa(word: str, with_batchim: str, without_batchim: str) -> str:
@@ -144,6 +195,15 @@ def build_steps(G, path, profile: Profile, merge_m: float = 15.0) -> list:
             maneuver = _maneuver_from_angle(turn_angle(prev_out, seg["in_bearing"]))
         special = lt in ("crossing", "elevator", "ramp", "steps")
 
+        # 노드 부착 횡단보도 안내 — 경로 중간 노드(seg 시작점).
+        # 앞뒤 어느 한쪽이 crossing 링크면 링크 스텝이 이미 횡단을 안내하므로 생략(중복 방지).
+        if i > 0 and lt != "crossing" and raw[i - 1]["data"]["link_type"] != "crossing":
+            cw = _node_crosswalk_step(G, seg["u"])
+            if cw is not None:
+                cw.update({"idx": len(steps), "_cw_point": True,
+                           "_link_type": None, "_maneuver_special": True})
+                steps.append(cw)
+
         merge_ok = (
             steps
             and maneuver == "straight"
@@ -176,10 +236,22 @@ def build_steps(G, path, profile: Profile, merge_m: float = 15.0) -> list:
                     "_end_node": seg["v"],
                 }
             )
+
+        # 출발 지점 부착분 — depart 스텝 뒤에 정보형으로 안내 (2-노드 경로 등에서
+        # 부착 노드가 출발점이면 중간 노드 안내만으로는 통째로 침묵하게 된다).
+        if i == 0 and lt != "crossing":
+            cw = _node_crosswalk_step(G, seg["u"], position="start")
+            if cw is not None:
+                cw.update({"idx": len(steps), "_cw_point": True,
+                           "_link_type": None, "_maneuver_special": True})
+                steps.append(cw)
         prev_out = seg["out_bearing"]
 
     out = []
     for s in steps:
+        if s.get("_cw_point"):
+            out.append({k: v for k, v in s.items() if not k.startswith("_")})
+            continue
         dist = s["distance_m"]
         instruction = _sentence(
             s["maneuver"] if s["maneuver"] in MANEUVER_LABEL else "straight",
@@ -201,6 +273,13 @@ def build_steps(G, path, profile: Profile, merge_m: float = 15.0) -> list:
                 "warnings": s["_warnings"],
             }
         )
+
+    # 도착 지점 부착분 — arrive 직전에 정보형으로 안내.
+    if raw[-1]["data"]["link_type"] != "crossing":
+        cw = _node_crosswalk_step(G, raw[-1]["v"], position="end")
+        if cw is not None:
+            cw["idx"] = len(out)
+            out.append(cw)
 
     last_coord = raw[-1]["coords"][-1]
     out.append(

--- a/scripts/apply_city_crosswalks.py
+++ b/scripts/apply_city_crosswalks.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""안양시 횡단보도 원천(mv_crosswalk)을 OSM 보행 그래프에 반영한다.
+
+3단계로 나눠 반영한다. 안양 OSM 보행망은 도로 중심선 위주(road 6,917 / sidewalk 2,063)라
+횡단보도 점 대부분이 "건너편 보도선"을 못 찾는다(2,728건 중 양쪽 뱅크 성립 189건).
+그래서 링크 생성을 강행하지 않고, 붙일 수 있는 만큼만 링크로 붙이고 나머지는 지점으로 부착한다.
+
+  [1] 매칭  — 기존 crossing 링크에 원천 속성 전이 (폭·길이·턱낮춤·점자블록)
+  [2] 신설  — 양쪽에 별개의 보행 링크가 실재하는 경우만 신규 crossing 링크 생성
+  [3] 부착  — 나머지는 최근접 보행 노드에 지점 메타로 부착 (안내 문구·경고용)
+
+curb_cut / tactile_paving 의 None 은 "없음"이 아니라 **미상**이다.
+planner.edge_passable 은 curb_cut is False 일 때만 차단하므로 이 계약을 그대로 유지한다.
+원천 기재율이 4.4% 라 미상을 없음으로 보수 처리하면 만안구 경로가 전멸한다.
+
+사용:
+  python scripts/apply_city_crosswalks.py \
+      --graph data/network_anyang_enriched.gpickle \
+      --crosswalks data/crosswalks_anyang_city.geojson \
+      --out data/network_anyang_cw.gpickle \
+      --report data/db_export/crosswalk_apply_report.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pickle
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+MATCH_RADIUS = 30.0    # m - 기존 crossing 링크 중점에서 원천 점을 찾는 반경
+BANK_ALONG   = 10.0    # m - 횡단 대상 도로축 방향 허용 오차
+BANK_MIN     = 1.5     # m - 이보다 가까우면 같은 지점으로 본다
+SPAN_MAX     = 60.0    # m - 이보다 긴 횡단 링크는 오접합으로 보고 버린다
+NODE_SNAP    = 3.0     # m - 투영점이 이 안이면 기존 노드를 그대로 쓴다
+ATTACH_RADIUS = 30.0   # m - 지점 부착 반경
+SRC = "city_cw2026"
+
+
+def _load_crosswalks(path, to_5186):
+    import numpy as np
+    with open(path, "r", encoding="utf-8") as f:
+        gj = json.load(f)
+    recs = []
+    for feat in gj.get("features", []):
+        g = feat.get("geometry") or {}
+        if g.get("type") != "Point":
+            continue
+        p = feat.get("properties") or {}
+        if p.get("src") and p["src"] != "anyang_city_2026":
+            continue
+        lon, lat = g["coordinates"][0], g["coordinates"][1]
+        recs.append({
+            "mgmt_no": p.get("mgmt_no"),
+            "lon": lon, "lat": lat,
+            "xy": to_5186(lon, lat),
+            "width": p.get("cw_width_m"),
+            "length": p.get("cw_length_m"),
+            "curb_cut": p.get("curb_cut"),
+            "tactile": p.get("tactile_paving"),
+            "dummy": p.get("survey_flag") == "dummy",
+        })
+    return recs
+
+
+def main():
+    import numpy as np
+    from pyproj import Transformer
+    from scipy.spatial import cKDTree
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--crosswalks", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--report")
+    args = ap.parse_args()
+
+    to_5186 = Transformer.from_crs("EPSG:4326", "EPSG:5186", always_xy=True).transform
+    to_wgs  = Transformer.from_crs("EPSG:5186", "EPSG:4326", always_xy=True).transform
+
+    with open(args.graph, "rb") as f:
+        G = pickle.load(f)
+    cw = _load_crosswalks(args.crosswalks, to_5186)
+    print("[0/4] 그래프 노드 %d / 링크 %d, 원천 횡단보도 %d"
+          % (G.number_of_nodes(), G.number_of_edges(), len(cw)))
+
+    stat = {"total": len(cw), "matched": 0, "matched_links": 0, "created": 0,
+            "attached": 0, "orphan": 0, "filled_width": 0, "filled_curb": 0,
+            "filled_tactile": 0, "split_nodes": 0, "span_reject": 0, "dup_reject": 0}
+    assign = {}
+
+    XY = {n: to_5186(a["lon"], a["lat"]) for n, a in G.nodes(data=True)}
+    P = np.array([r["xy"] for r in cw])
+    used = set()
+
+    # ---------------------------------------------------------------- [1] 매칭
+    # 기존 crossing 링크마다 반경 안 최근접 원천 점의 속성을 전이한다.
+    # OSM 은 중앙분리대가 있는 횡단보도를 두 링크로 쪼개 두는 경우가 있어
+    # 한 원천 점이 여러 링크에 대응할 수 있다 - 1:1 로 묶지 않는다.
+    ptree = cKDTree(P)
+    for u, v, e in list(G.edges(data=True)):
+        if e.get("link_type") != "crossing":
+            continue
+        mx = np.array(((XY[u][0] + XY[v][0]) / 2.0, (XY[u][1] + XY[v][1]) / 2.0))
+        d, i = ptree.query(mx, k=1)
+        if d > MATCH_RADIUS:
+            continue
+        i = int(i); r = cw[i]
+        if r["width"]:
+            e["width"] = float(r["width"]); stat["filled_width"] += 1
+        if r["length"]:
+            e["cw_length_m"] = float(r["length"])
+        if r["curb_cut"] is not None:
+            e["curb_cut"] = bool(r["curb_cut"]); stat["filled_curb"] += 1
+        if r["tactile"] is not None:
+            e["tactile_paving"] = bool(r["tactile"]); stat["filled_tactile"] += 1
+        e["cw_mgmt_no"] = r["mgmt_no"]
+        e["attr_source"] = SRC
+        stat["matched_links"] += 1
+        if i not in used:
+            used.add(i)
+            stat["matched"] += 1
+            assign[r["mgmt_no"]] = {"how": "exist", "dist": round(float(d), 1)}
+    print("[1/4] 기존 crossing 링크 %d건에 원천 속성 전이 (원천 %d건 소화, "
+          "폭 %d / 턱낮춤 %d / 점자블록 %d)"
+          % (stat["matched_links"], stat["matched"], stat["filled_width"],
+             stat["filled_curb"], stat["filled_tactile"]))
+
+    # ---------------------------------------------------------------- [2] 신설
+    # 양쪽에 별개의 보행 링크가 실재할 때만 신규 crossing 링크를 만든다.
+    # 도로 중심선 위 두 점을 잇는 자기루프를 막기 위해 "마주보기" 조건을 건다.
+    #
+    # 2패스로 나눈다. 1패스에서 원본 형상만 보고 접속점(edge, t)을 전부 계산하고,
+    # 2패스에서 링크별로 모아 한 번에 분할한다. 한 패스로 하면 이미 분할한 링크를
+    # 다시 분할하려다 접속점이 기존 노드로 붕괴해 링크가 대량으로 사라진다.
+    E = [(u, v, d) for u, v, d in G.edges(data=True)]
+    A = np.array([XY[u] for u, v, d in E])
+    B = np.array([XY[v] for u, v, d in E])
+    TY = [d.get("link_type") for u, v, d in E]
+    AB = B - A
+    L2 = (AB ** 2).sum(1); L2[L2 == 0] = 1e-9
+    mid = (A + B) / 2.0
+    half = np.sqrt(L2) / 2.0
+    mtree = cKDTree(mid)
+    HM = float(half.max())
+
+    def near_edges(p, rad):
+        idx = np.array(mtree.query_ball_point(p, rad + HM), dtype=int)
+        if idx.size == 0:
+            return []
+        t = np.clip(((p - A[idx]) * AB[idx]).sum(1) / L2[idx], 0, 1)
+        proj = A[idx] + t[:, None] * AB[idx]
+        dd = np.sqrt(((proj - p) ** 2).sum(1))
+        keep = dd <= rad
+        return list(zip(idx[keep], proj[keep], dd[keep], t[keep]))
+
+    # --- 1패스: 접속점 수집
+    plan = []          # (cw_index, (edge_k, t, proj), (edge_k, t, proj), span)
+    cuts = {}          # edge_k -> [t, ...]
+    for i, r in enumerate(cw):
+        if i in used:
+            continue
+        p = P[i]
+        L = float(r["length"] or 0) or 15.0
+        rad = min(max(L * 0.75, 12.0), 40.0)
+        cand = near_edges(p, rad)
+        if not cand:
+            continue
+        roads = [c for c in cand if TY[int(c[0])] == "road"]
+        ref = min(roads, key=lambda c: c[2]) if roads else min(cand, key=lambda c: c[2])
+        j = int(ref[0])
+        ax = AB[j] / math.sqrt(L2[j])
+        nv = np.array([-ax[1], ax[0]])
+        sides = {1: None, -1: None}
+        for (k, proj, dd, t) in cand:
+            if int(k) == j:
+                continue
+            rel = proj - p
+            perp = float(rel @ nv)
+            if abs(float(rel @ ax)) > BANK_ALONG or abs(perp) < BANK_MIN:
+                continue
+            s = 1 if perp > 0 else -1
+            if sides[s] is None or abs(perp) < abs(sides[s][1]):
+                sides[s] = (int(k), float(t), proj, abs(perp))
+        if not (sides[1] and sides[-1]):
+            continue
+        span = float(np.linalg.norm(sides[1][2] - sides[-1][2]))
+        if span > min(max(L * 1.6, 20.0), SPAN_MAX):
+            stat["span_reject"] += 1
+            continue
+        plan.append((i, sides[1], sides[-1], span))
+        for s in (sides[1], sides[-1]):
+            cuts.setdefault(s[0], []).append(s[1])
+
+    # --- 2패스: 링크별 일괄 분할
+    node_at = {}       # (edge_k, t) -> node_id
+    new_id = 0
+    for k, ts in cuts.items():
+        u, v, _ = E[k]
+        if not G.has_edge(u, v):
+            continue
+        old = dict(G[u][v])
+        seg_len = float(old.get("length") or math.sqrt(L2[k]))
+        pts = sorted(set(round(t, 6) for t in ts))
+        chain = [(0.0, u)]
+        for t in pts:
+            pos = A[k] + t * AB[k]
+            if float(np.linalg.norm(pos - XY[u])) <= NODE_SNAP:
+                node_at[(k, t)] = u; continue
+            if float(np.linalg.norm(pos - XY[v])) <= NODE_SNAP:
+                node_at[(k, t)] = v; continue
+            new_id += 1
+            nid = "cwx%06d" % new_id
+            lon, lat = to_wgs(float(pos[0]), float(pos[1]))
+            G.add_node(nid, lat=lat, lon=lon, node_type="crossing")
+            XY[nid] = (float(pos[0]), float(pos[1]))
+            node_at[(k, t)] = nid
+            chain.append((t, nid))
+            stat["split_nodes"] += 1
+        if len(chain) == 1:
+            continue
+        chain.append((1.0, v))
+        G.remove_edge(u, v)
+        for (t0, n0), (t1, n1) in zip(chain[:-1], chain[1:]):
+            if n0 == n1:
+                continue
+            a = dict(old)
+            a["length"] = max(seg_len * (t1 - t0), 0.1)
+            a["geometry"] = None
+            G.add_edge(n0, n1, **a)
+
+    # --- 횡단 링크 연결
+    for i, s1, s2, span in plan:
+        r = cw[i]
+        na = node_at.get((s1[0], round(s1[1], 6)))
+        nb = node_at.get((s2[0], round(s2[1], 6)))
+        if na is None or nb is None or na == nb or G.has_edge(na, nb):
+            stat["dup_reject"] += 1
+            continue
+        G.add_edge(na, nb, length=span, slope=0.0, link_type="crossing",
+                   width=(float(r["width"]) if r["width"] else None),
+                   curb_cut=(bool(r["curb_cut"]) if r["curb_cut"] is not None else None),
+                   tactile_paving=(bool(r["tactile"]) if r["tactile"] is not None else None),
+                   surface=None, link_name=None, geometry=None,
+                   cw_mgmt_no=r["mgmt_no"], cw_length_m=r["length"], attr_source=SRC)
+        used.add(i)
+        stat["created"] += 1
+        assign[r["mgmt_no"]] = {"how": "new", "node": str(na), "dist": round(span, 1)}
+    print("[2/4] 신규 crossing 링크 %d건 생성 (후보 %d · 노드 분할 %d · "
+          "스팬 초과 기각 %d · 중복 기각 %d)"
+          % (stat["created"], len(plan), stat["split_nodes"],
+             stat["span_reject"], stat["dup_reject"]))
+
+    # ---------------------------------------------------------------- [3] 부착
+    # 링크로 못 붙인 나머지는 최근접 보행 노드에 "지점"으로 단다.
+    # 위상은 바뀌지 않는다. 경로가 이 노드를 지날 때 횡단 안내를 낼 수 있게 하는 것이 목적.
+    ids = list(G.nodes)
+    NXY = np.array([XY[n] for n in ids])
+    ntree = cKDTree(NXY)
+    for i, r in enumerate(cw):
+        if i in used:
+            continue
+        d, k = ntree.query(P[i], k=1)
+        if d > ATTACH_RADIUS:
+            stat["orphan"] += 1
+            assign[r["mgmt_no"]] = {"how": "orphan", "dist": round(float(d), 1)}
+            continue
+        n = ids[int(k)]
+        a = G.nodes[n]
+        a["crosswalk_cnt"] = int(a.get("crosswalk_cnt") or 0) + 1
+        lst = a.get("cw_mgmt_nos") or []
+        lst.append(r["mgmt_no"])
+        a["cw_mgmt_nos"] = lst
+        if r["curb_cut"] is not None:
+            prev = a.get("cw_curb_cut")
+            a["cw_curb_cut"] = bool(r["curb_cut"]) if prev is None else (prev and bool(r["curb_cut"]))
+        if r["tactile"] is not None:
+            prev = a.get("cw_tactile_paving")
+            a["cw_tactile_paving"] = bool(r["tactile"]) if prev is None else (prev and bool(r["tactile"]))
+        if a.get("node_type") in (None, "unknown"):
+            a["node_type"] = "crossing"
+        stat["attached"] += 1
+        assign[r["mgmt_no"]] = {"how": "point", "node": str(n), "dist": round(float(d), 1)}
+    print("[3/4] 지점 부착 %d건 / 반경 밖 %d건" % (stat["attached"], stat["orphan"]))
+
+    # ---------------------------------------------------------------- 저장
+    with open(args.out, "wb") as f:
+        pickle.dump(G, f)
+    types = {}
+    for _, _, d in G.edges(data=True):
+        t = d.get("link_type")
+        types[t] = types.get(t, 0) + 1
+    stat["nodes"] = G.number_of_nodes()
+    stat["edges"] = G.number_of_edges()
+    stat["link_types"] = types
+    stat["crossing_nodes"] = sum(1 for _, a in G.nodes(data=True) if a.get("crosswalk_cnt"))
+    print("[4/4] 저장: %s  노드 %d / 링크 %d" % (args.out, stat["nodes"], stat["edges"]))
+    print("      링크타입: %s" % types)
+    print("      횡단보도가 달린 노드 %d개" % stat["crossing_nodes"])
+    cover = stat["matched"] + stat["created"] + stat["attached"]
+    print("      원천 반영률 %d/%d (%.1f%%)  [매칭 %d · 신설 %d · 부착 %d · 미반영 %d]"
+          % (cover, stat["total"], cover / stat["total"] * 100,
+             stat["matched"], stat["created"], stat["attached"],
+             stat["total"] - cover))
+    if args.report:
+        os.makedirs(os.path.dirname(os.path.abspath(args.report)) or ".", exist_ok=True)
+        with open(args.report, "w", encoding="utf-8") as f:
+            json.dump({"stat": stat, "assign": assign}, f, ensure_ascii=False)
+        print("      리포트: %s" % args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_graph_tables.py
+++ b/scripts/export_graph_tables.py
@@ -32,10 +32,14 @@ def main():
 
     with open(node_path, "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(["node_id", "lat", "lon", "node_type", "network_version"])
+        w.writerow(["node_id", "lat", "lon", "node_type",
+                    "crosswalk_cnt", "cw_mgmt_nos", "network_version"])
         for n, d in G.nodes(data=True):
             w.writerow([n, d.get("lat"), d.get("lon"),
-                        d.get("node_type") or "unknown", args.version])
+                        d.get("node_type") or "unknown",
+                        int(d.get("crosswalk_cnt") or 0),
+                        ",".join(d.get("cw_mgmt_nos") or []),
+                        args.version])
 
     def _b(v):
         return {True: "true", False: "false"}.get(v, "")
@@ -43,8 +47,9 @@ def main():
     with open(link_path, "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow(["f_node", "t_node", "length_m", "link_type", "width_m",
-                    "slope_pct", "surface", "curb_cut", "link_name",
-                    "topo_source", "network_version"])
+                    "slope_pct", "surface", "curb_cut", "tactile_paving",
+                    "link_name", "topo_source", "cw_mgmt_no", "attr_source",
+                    "network_version"])
         for u, v, d in G.edges(data=True):
             w.writerow([
                 u, v, round(float(d.get("length") or 0), 2),
@@ -53,8 +58,11 @@ def main():
                 d.get("slope") if d.get("slope") is not None else "",
                 d.get("surface") or "",
                 _b(d.get("curb_cut")),
+                _b(d.get("tactile_paving")),
                 d.get("link_name") or "",
                 d.get("topo_source") or "",
+                d.get("cw_mgmt_no") or "",
+                d.get("attr_source") or "",
                 args.version,
             ])
 

--- a/scripts/simulate_crosswalk_effect.py
+++ b/scripts/simulate_crosswalk_effect.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""실증 도보 구간을 그래프 두 벌로 각각 탐색해 전/후를 비교한다.
+
+횡단보도 반영이 실제 안내에 무엇을 바꾸는지 링크 단위로 본다. 관측 항목:
+  - 거리·소요시간·최대경사              : 경로 자체가 바뀌었는가
+  - crossing 링크 수                    : 횡단 안내를 낼 수 있는가 (기존 지표)
+  - 경로가 지나는 노드의 부착 횡단보도  : 링크로는 못 붙었지만 지점으로 아는 횡단보도
+  - curb_cut 판정 분포(있음/없음/미상)  : 휠체어 통행 가부를 말할 수 있는 비율
+
+사용:
+  python scripts/simulate_crosswalk_effect.py \
+      --before data/network_anyang_enriched.gpickle \
+      --after  data/network_anyang_cw.gpickle \
+      --legs   data/db_export/demo_legs.json \
+      --out    data/db_export/crosswalk_sim_report.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pickle
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import networkx as nx  # noqa: E402
+
+from route_service.engine.geo import haversine_m          # noqa: E402
+from route_service.engine.planner import edge_passable, edge_cost  # noqa: E402
+from route_service.engine.profiles import get_profile     # noqa: E402
+
+
+def _snap(G, lat, lon):
+    best, bd = None, 1e18
+    for n, a in G.nodes(data=True):
+        d = haversine_m(lat, lon, a["lat"], a["lon"])
+        if d < bd:
+            best, bd = n, d
+    return best, bd
+
+
+def _route(G, prof, s, t):
+    max_slope = prof.max_slope_deg
+
+    def weight(u, v, data):
+        if not edge_passable(data, prof, max_slope):
+            return None
+        return edge_cost(data, prof)
+
+    def h(u, v):
+        return haversine_m(G.nodes[u]["lat"], G.nodes[u]["lon"],
+                           G.nodes[v]["lat"], G.nodes[v]["lon"])
+    return nx.astar_path(G, s, t, heuristic=h, weight=weight)
+
+
+def _measure(G, path, prof):
+    dist = 0.0
+    crossing = 0
+    slopes = []
+    curb = {"yes": 0, "no": 0, "unknown": 0}
+    width_known = 0
+    for u, v in zip(path[:-1], path[1:]):
+        d = G[u][v]
+        dist += float(d.get("length") or 0)
+        slopes.append(float(d.get("slope") or 0))
+        if d.get("link_type") == "crossing":
+            crossing += 1
+            c = d.get("curb_cut")
+            curb["yes" if c is True else "no" if c is False else "unknown"] += 1
+            if d.get("width"):
+                width_known += 1
+    node_cw = sum(int(G.nodes[n].get("crosswalk_cnt") or 0) for n in path)
+    node_cw_nodes = sum(1 for n in path if G.nodes[n].get("crosswalk_cnt"))
+    return {
+        "distance_m": round(dist),
+        "duration_s": round(dist / prof.speed_mps) if prof.speed_mps else None,
+        "max_slope_deg": round(max(slopes), 2) if slopes else 0.0,
+        "links": len(path) - 1,
+        "crossing_links": crossing,
+        "crossing_width_known": width_known,
+        "curb_cut": curb,
+        "node_crosswalks": node_cw,
+        "node_crosswalk_nodes": node_cw_nodes,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--before", required=True)
+    ap.add_argument("--after", required=True)
+    ap.add_argument("--legs", required=True)
+    ap.add_argument("--profile", default="wheelchair_manual")
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    prof = get_profile(args.profile)
+    legs = json.load(open(args.legs, encoding="utf-8"))
+    graphs = {}
+    for tag, p in (("before", args.before), ("after", args.after)):
+        with open(p, "rb") as f:
+            graphs[tag] = pickle.load(f)
+        g = graphs[tag]
+        print("%-6s 노드 %5d / 링크 %5d" % (tag, g.number_of_nodes(), g.number_of_edges()))
+
+    rows = []
+    for leg in legs:
+        row = {"name": leg["name"]}
+        for tag, G in graphs.items():
+            s, ds = _snap(G, leg["from"][0], leg["from"][1])
+            t, dt = _snap(G, leg["to"][0], leg["to"][1])
+            try:
+                path = _route(G, prof, s, t)
+                m = _measure(G, path, prof)
+            except Exception as e:
+                m = {"error": str(e)}
+            m["snap_m"] = [round(ds), round(dt)]
+            row[tag] = m
+        rows.append(row)
+
+    print("\n%-26s %9s %9s %8s %8s %9s"
+          % ("구간", "거리(전)", "거리(후)", "횡단(전)", "횡단(후)", "지점부착"))
+    print("-" * 76)
+    for r in rows:
+        b, a = r.get("before", {}), r.get("after", {})
+        print("%-26s %9s %9s %8s %8s %9s"
+              % (r["name"][:26],
+                 b.get("distance_m", "-"), a.get("distance_m", "-"),
+                 b.get("crossing_links", "-"), a.get("crossing_links", "-"),
+                 a.get("node_crosswalks", "-")))
+
+    tot = {"crossing_before": 0, "crossing_after": 0, "node_cw": 0,
+           "curb_known": 0, "curb_unknown": 0, "changed_route": 0}
+    for r in rows:
+        b, a = r.get("before", {}), r.get("after", {})
+        tot["crossing_before"] += b.get("crossing_links", 0)
+        tot["crossing_after"] += a.get("crossing_links", 0)
+        tot["node_cw"] += a.get("node_crosswalks", 0)
+        c = a.get("curb_cut") or {}
+        tot["curb_known"] += c.get("yes", 0) + c.get("no", 0)
+        tot["curb_unknown"] += c.get("unknown", 0)
+        if b.get("distance_m") != a.get("distance_m"):
+            tot["changed_route"] += 1
+    print("\n합계  crossing 링크 %d -> %d / 노드 부착 횡단보도 %d / "
+          "턱낮춤 판정가능 %d·미상 %d / 경로 변경 %d개 구간"
+          % (tot["crossing_before"], tot["crossing_after"], tot["node_cw"],
+             tot["curb_known"], tot["curb_unknown"], tot["changed_route"]))
+
+    if args.out:
+        os.makedirs(os.path.dirname(os.path.abspath(args.out)) or ".", exist_ok=True)
+        json.dump({"profile": args.profile, "legs": rows, "total": tot},
+                  open(args.out, "w", encoding="utf-8"), ensure_ascii=False, indent=1)
+        print("리포트: %s" % args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sql/crosswalk_schema.sql
+++ b/scripts/sql/crosswalk_schema.sql
@@ -1,0 +1,61 @@
+-- 안양시 횡단보도 원천 (02-IITP-DABT-Route v1.13.0)
+-- 원천: data.go.kr 15042415 "경기도 안양시_공간정보시스템_횡단보도 현황" 좌표 포함본(2026-08-26 배포)
+--       안양시 스마트도시정보과 공간정보시스템 발췌. 2,728건.
+-- 명명: mv_ (mobility) 접두 규약 — mv_poi / mv_pednet_node / mv_pednet_link 와 동일 계열
+--
+-- ⚠️ 접근성 컬럼 결측 주의
+--   보도턱낮춤여부·점자블록유무는 2,728건 중 175건(6.4%)만 기재돼 있고,
+--   그중 56건은 폭·길이가 0인 미조사 더미행("기타")이다. 실질 유효는 119건(4.4%).
+--   따라서 curb_cut / tactile_paving 의 NULL 은 "없음"이 아니라 **미상**이다.
+--   라우팅 엔진(planner.edge_passable)은 curb_cut IS FALSE 일 때만 차단하고
+--   NULL 은 통과시키되 안내에 "턱낮춤 미상"으로 노출한다. 이 계약을 바꾸지 말 것.
+
+CREATE TABLE IF NOT EXISTS mv_crosswalk (
+    src_version      VARCHAR(20)  NOT NULL,          -- 원천 배포일 (예: 20260826)
+    mgmt_no          VARCHAR(20)  NOT NULL,          -- 관리번호 (안양시 자연키, 2024xxxxxx/2025xxxxxx)
+    lat              DOUBLE PRECISION NOT NULL,
+    lon              DOUBLE PRECISION NOT NULL,
+    width_m          NUMERIC(6,2),                   -- 횡단보도폭 = 도색 띠 폭(보행 유효폭). 0 -> NULL
+    length_m         NUMERIC(6,2),                   -- 횡단보도길이 = 횡단 거리(차도 폭). 0 -> NULL
+    dong_name        VARCHAR(40),                    -- 관할지역(행정동). '경기도 안양시' = 동 미기재
+    curb_cut         BOOLEAN,                        -- 보도턱낮춤: 있음=TRUE / 없음=FALSE / 기타·공란=NULL(미상)
+    tactile_paving   BOOLEAN,                        -- 점자블록: 동일 규칙
+    survey_flag      VARCHAR(10)  NOT NULL DEFAULT 'ok',  -- ok | dummy(폭·길이 0 = 원천 미조사행)
+    src_name         VARCHAR(80)  NOT NULL DEFAULT '안양시 공간정보시스템 횡단보도 현황',
+    match_link_type  VARCHAR(12),                    -- exist(기존 crossing 매칭) | new(신규 링크 생성) | point(지점 부착) | orphan
+    match_node_id    VARCHAR(20),                    -- 부착된 보행망 노드 (point/new 인 경우)
+    match_dist_m     NUMERIC(6,2),                   -- 부착 거리
+    network_version  VARCHAR(40),                    -- 매칭 대상 보행망 버전
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (src_version, mgmt_no)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mv_crosswalk_latlon  ON mv_crosswalk (lat, lon);
+CREATE INDEX IF NOT EXISTS idx_mv_crosswalk_dong    ON mv_crosswalk (dong_name);
+CREATE INDEX IF NOT EXISTS idx_mv_crosswalk_match   ON mv_crosswalk (network_version, match_node_id);
+
+COMMENT ON TABLE  mv_crosswalk IS '안양시 횡단보도 원천 (data.go.kr 15042415, 좌표 포함본) — curb_cut/tactile_paving 의 NULL 은 미상';
+COMMENT ON COLUMN mv_crosswalk.curb_cut       IS '보도턱낮춤 여부. NULL = 미상(원천 기재율 4.4%)';
+COMMENT ON COLUMN mv_crosswalk.tactile_paving IS '점자블록 유무. NULL = 미상';
+COMMENT ON COLUMN mv_crosswalk.survey_flag    IS 'dummy = 원천에서 폭·길이 0 으로 들어온 미조사행(56건)';
+
+
+-- ################################################
+-- ## mv_pednet_link 확장 — 횡단보도 원천 연계
+-- ################################################
+ALTER TABLE mv_pednet_link ADD COLUMN IF NOT EXISTS tactile_paving BOOLEAN;
+ALTER TABLE mv_pednet_link ADD COLUMN IF NOT EXISTS cw_mgmt_no     VARCHAR(20);   -- mv_crosswalk.mgmt_no
+ALTER TABLE mv_pednet_link ADD COLUMN IF NOT EXISTS attr_source    VARCHAR(20);   -- city_cw2026 | topo1k | topo5k | osm
+
+COMMENT ON COLUMN mv_pednet_link.tactile_paving IS '점자블록 유무. NULL = 미상';
+COMMENT ON COLUMN mv_pednet_link.cw_mgmt_no     IS '매칭된 안양시 횡단보도 관리번호 (mv_crosswalk)';
+COMMENT ON COLUMN mv_pednet_link.attr_source    IS 'width_m/curb_cut 등 속성의 출처';
+
+
+-- ################################################
+-- ## mv_pednet_node 확장 — 횡단보도 지점 부착
+-- ################################################
+ALTER TABLE mv_pednet_node ADD COLUMN IF NOT EXISTS crosswalk_cnt  SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE mv_pednet_node ADD COLUMN IF NOT EXISTS cw_mgmt_nos    TEXT;          -- 쉼표구분 관리번호 목록
+
+COMMENT ON COLUMN mv_pednet_node.crosswalk_cnt IS '이 노드에 부착된 안양시 횡단보도 개수 (안내 문구 생성용)';

--- a/tests/test_crosswalk_guidance.py
+++ b/tests/test_crosswalk_guidance.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""노드 지점 부착 횡단보도 안내 계층 (v1.13.0).
+
+안양시 원천 횡단보도 다수는 crossing 링크가 아니라 최근접 노드에 지점 부착돼 있다.
+안내 계층은 경로가 그 노드를 지날 때 횡단 안내 스텝을 만들어야 하고,
+위상(경로·거리)과 기존 crossing_cnt 계약은 건드리지 않아야 한다.
+"""
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from route_service.engine.graph import NetworkStore
+from route_service.engine.planner import plan
+from route_service.engine.profiles import get_profile
+from route_service.engine.steps import build_steps
+
+
+def _base_graph() -> nx.Graph:
+    """N1 --sidewalk-- N2 --sidewalk-- N3 (일자 경로)."""
+    G = nx.Graph()
+    G.add_node("N1", lat=37.3900, lon=126.9500, node_type="intersection")
+    G.add_node("N2", lat=37.3900, lon=126.9511, node_type="intersection")
+    G.add_node("N3", lat=37.3909, lon=126.9511, node_type="entrance")
+    G.add_edge("N1", "N2", length=100.0, slope=1.0, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface="asphalt", link_name="예시로", geometry=None)
+    G.add_edge("N2", "N3", length=100.0, slope=1.5, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface="asphalt", link_name="예시2로", geometry=None)
+    return G
+
+
+def _store(G) -> NetworkStore:
+    s = NetworkStore()
+    s.load_graph_object(G, version="test-cw", region="테스트")
+    return s
+
+
+def _route(store, profile_id="wheelchair_manual"):
+    p = get_profile(profile_id)
+    r = plan(store, "N1", "N3", p)["routes"][0]
+    return p, r
+
+
+def test_crossing_point_step_generated_with_unknown_curb_cut():
+    """부착 노드를 지나면 안내 스텝이 생기고, 턱낮춤 None 은 '미상'으로 표기돼야 한다."""
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=1, cw_mgmt_nos=["2024000001"],
+                         cw_curb_cut=None, cw_tactile_paving=None)
+    p, r = _route(_store(G))
+    steps = build_steps(_store(G).graph, r["path"], p)
+
+    cw = [s for s in steps if s["maneuver"] == "crossing_point"]
+    assert len(cw) == 1
+    assert "횡단보도" in cw[0]["instruction"]
+    assert "턱낮춤 미상" in cw[0]["warnings"]
+    assert cw[0]["distance_m"] == 0
+    assert cw[0]["crosswalk_cnt"] == 1
+    # 노드 좌표에 붙어야 한다
+    assert cw[0]["coord"] == [37.39, 126.9511]
+
+
+def test_crossing_point_step_warns_when_no_curb_cut():
+    """턱낮춤 False 는 미상이 아니라 명시 경고."""
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=1, cw_curb_cut=False, cw_tactile_paving=False)
+    p, r = _route(_store(G))
+    steps = build_steps(_store(G).graph, r["path"], p)
+
+    cw = [s for s in steps if s["maneuver"] == "crossing_point"][0]
+    assert "턱낮춤 없음" in cw["warnings"]
+    assert "점자블록 없음" in cw["warnings"]
+    assert "턱낮춤 미상" not in cw["warnings"]
+
+
+def test_multiple_crosswalks_on_node_mentioned_in_instruction():
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=3, cw_curb_cut=None)
+    p, r = _route(_store(G))
+    steps = build_steps(_store(G).graph, r["path"], p)
+    cw = [s for s in steps if s["maneuver"] == "crossing_point"][0]
+    assert "3개" in cw["instruction"]
+    assert cw["crosswalk_cnt"] == 3
+
+
+def test_depart_arrive_and_idx_remain_consistent():
+    """안내 스텝이 끼어들어도 출발/도착과 idx 연속성은 유지돼야 한다."""
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=1, cw_curb_cut=None)
+    p, r = _route(_store(G))
+    steps = build_steps(_store(G).graph, r["path"], p)
+    assert steps[0]["maneuver"] == "depart"
+    assert steps[-1]["maneuver"] == "arrive"
+    assert [s["idx"] for s in steps] == list(range(len(steps)))
+
+
+def test_no_duplicate_announcement_next_to_crossing_link():
+    """crossing 링크 앞뒤 노드의 지점 부착분은 링크 안내와 중복되므로 생략."""
+    G = nx.Graph()
+    G.add_node("N1", lat=37.3900, lon=126.9500, node_type="intersection")
+    G.add_node("N2", lat=37.3900, lon=126.9511, node_type="crossing")
+    G.add_node("N3", lat=37.3902, lon=126.9513, node_type="crossing")
+    G.add_node("N4", lat=37.3909, lon=126.9513, node_type="entrance")
+    G.add_edge("N1", "N2", length=100.0, slope=0.5, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    G.add_edge("N2", "N3", length=20.0, slope=0.0, link_type="crossing",
+               width=3.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    G.add_edge("N3", "N4", length=80.0, slope=0.5, link_type="sidewalk",
+               width=2.0, curb_cut=True, surface=None, link_name=None, geometry=None)
+    G.nodes["N2"].update(crosswalk_cnt=1, cw_curb_cut=None)
+    G.nodes["N3"].update(crosswalk_cnt=1, cw_curb_cut=None)
+
+    store = _store(G)
+    p = get_profile("wheelchair_manual")
+    r = plan(store, "N1", "N4", p)["routes"][0]
+    steps = build_steps(store.graph, r["path"], p)
+
+    assert not [s for s in steps if s["maneuver"] == "crossing_point"]
+    # crossing 링크 자체의 안내는 그대로 있어야 한다
+    assert any(s["link_type"] == "crossing" for s in steps)
+
+
+def test_summary_counts_point_crosswalks_separately():
+    """summary.crossing_point_cnt 는 노드 부착분 합계, crossing_cnt 는 링크 수 그대로."""
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=2, cw_curb_cut=None)
+    G.nodes["N3"].update(crosswalk_cnt=1, cw_curb_cut=None)
+    p, r = _route(_store(G))
+
+    assert r["summary"]["crossing_point_cnt"] == 3   # 경로 노드 전체 합
+    assert r["summary"]["crossing_cnt"] == 0         # crossing 링크는 없음 — 의미 불변
+
+
+def test_summary_warns_when_attached_crosswalk_lacks_curb_cut():
+    G = _base_graph()
+    G.nodes["N2"].update(crosswalk_cnt=1, cw_curb_cut=False)
+    p, r = _route(_store(G))
+    assert "턱낮춤 없는 횡단보도 구간이 있습니다" in r["summary"]["warnings"]
+
+
+def test_endpoint_crosswalks_get_informational_steps():
+    """출발·도착 노드 부착분도 침묵하지 않아야 한다(실증 2b·3a: 2-노드 경로).
+
+    다만 실제 횡단 여부를 단정할 수 없으므로 지시형("건너세요") 대신 정보형으로 알린다.
+    """
+    G = _base_graph()
+    G.nodes["N1"].update(crosswalk_cnt=4, cw_curb_cut=None)
+    G.nodes["N3"].update(crosswalk_cnt=1, cw_curb_cut=None)
+    p, r = _route(_store(G))
+    steps = build_steps(_store(G).graph, r["path"], p)
+
+    cw = [s for s in steps if s["maneuver"] == "crossing_point"]
+    assert len(cw) == 2
+    assert "출발 지점에 횡단보도 4개가 있습니다" in cw[0]["instruction"]
+    assert "도착 지점에 횡단보도가 있습니다" in cw[1]["instruction"]
+    assert "건너세요" not in cw[0]["instruction"]
+    # 순서 계약: depart 가 항상 처음, arrive 가 항상 마지막
+    assert steps[0]["maneuver"] == "depart"
+    assert steps[-1]["maneuver"] == "arrive"
+    assert [s["idx"] for s in steps] == list(range(len(steps)))
+
+
+def test_plain_graph_unchanged(store):
+    """부착 정보가 없는 그래프(기존 픽스처)는 이전과 동일하게 동작해야 한다."""
+    p = get_profile("wheelchair_manual")
+    r = plan(store, "N1", "N3", p)["routes"][0]
+    steps = build_steps(store.graph, r["path"], p)
+    assert not [s for s in steps if s["maneuver"] == "crossing_point"]
+    assert r["summary"]["crossing_point_cnt"] == 0


### PR DESCRIPTION
## 변경 내용

안양시 횡단보도 원천을 반영한 그래프에서 노드에 지점 부착된 횡단보도(crosswalk_cnt)를 턴바이턴 안내가 읽도록 안내 전용 계층을 추가한다. 경로 탐색·비용·위상에는 일절 관여하지 않는다.

- `engine/steps.py`: 경로가 부착 노드를 지나면 `maneuver="crossing_point"` 안내 스텝 생성 (distance_m 0, 노드 좌표). 중간 노드는 횡단 지시형, 출발·도착 노드는 정보형 문장. 턱낮춤 `False` = "턱낮춤 없음" 경고, `None` = "턱낮춤 미상" 표기(없음으로 처리 금지). crossing 링크 인접 노드는 링크 안내와 중복되므로 생략
- `engine/planner.py`: `summary.crossing_point_cnt` 추가 (경로 노드 부착분 합계). 기존 `crossing_cnt`(crossing 링크 수) 의미 불변. 부착분 턱낮춤 `False` 시 summary 경고 추가
- `api/main.py`: 멀티모달 통합 요약에도 `crossing_point_cnt` 집계
- `api/schemas.py`·`engine/graph.py`: 응답·그래프 스키마 문서화 (cw_* 노드/링크 속성, `tactile_paving` 링크 기본값)
- `scripts/export_graph_tables.py`: node 내보내기에 `crosswalk_cnt`·`cw_mgmt_nos`, link 에 `tactile_paving`·`cw_mgmt_no`·`attr_source` 확장 (DDL 은 crosswalk_schema.sql 로 적용됨)
- 신규 스크립트 등재: `apply_city_crosswalks.py`(매칭·신설·부착 3단계 반영), `simulate_crosswalk_effect.py`(전/후 비교), `sql/crosswalk_schema.sql`(mv_crosswalk DDL + pednet 확장)

## 테스트 방법

- `python3 -m pytest -q` 80건 전건 통과 (신규 tests/test_crosswalk_guidance.py 9건 포함)
- 반영 그래프(network_anyang_cw.gpickle)로 실증 6개 도보 구간 재탐색: 경로·거리 전부 불변, `crossing_point_cnt` 합계 86 (시뮬레이션 보고서와 일치), 안내 스텝 38건 생성 확인

Closes #39