### PR TITLE
v1.17.0 - 접근성 제보 삭제 API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.16.0 |
+| 02-IITP-DABT-Route | v1.17.0 |
 
 ## 구조
 
@@ -133,6 +133,12 @@ curl -s localhost:18100/meta/network
 | GET | `/tour/bf-spots/{id}/entrance` | **무장애 접근 지점** — 실측 출입구 > 건물 접근점 > 시설 대표점 |
 | POST | `/tour/recommend` | 장애 유형별 관광지 추천 랭킹 — `origin_lat/lng` 지정 시 **거리 오름차순**, `offset` 페이징(`total`/`has_more` 반환) |
 | GET | `/transit/access-points` | 휠체어 접근 가능한 정류장·역 |
+| POST | `/track/log` | 주행 GPS 트랙 적재 (참여자 식별자 없음 — `route_id` 익명) |
+| POST | `/report/accessibility` | 접근성 오류 제보 — 접수 즉시 '이용자 제보(미확인)' 경고 부착 |
+| GET | `/report/accessibility` | 제보 목록 (관리 콘솔용) |
+| GET | `/report/accessibility/{id}/photo` | 제보 사진 |
+| PATCH | `/report/accessibility/{id}` | 검토 — confirm(확정) / reject(기각) / apply(속성 반영, 승인제) |
+| DELETE | `/report/accessibility/{id}` | **제보 삭제** — 오검·중복·시험 제보 정리. 파생 오버라이드도 함께 사라진다 |
 | POST | `/admin/reload-network` | 그래프 무중단 교체 |
 
 ### 경로 탐색 예시

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -748,6 +748,25 @@ def review_accessibility_report(report_id: int, req: ReportReviewRequest):
     return {**out, "overrides": stat}
 
 
+@app.delete("/report/accessibility/{report_id}", tags=["collect"],
+            dependencies=[Depends(auth)])
+def delete_accessibility_report(report_id: int):
+    """제보 삭제 — 오검·중복·시험 제보 정리용. 파생 오버라이드도 함께 사라진다.
+
+    검토(PATCH reject)는 '확인했고 사실이 아님'을 남기는 기록이고, 이쪽은 기록 자체를
+    지운다. 삭제 즉시 오버라이드를 재적용해 그래프에서 경고를 걷어낸다.
+    """
+    try:
+        out = collect_store.STORE.delete_report(report_id)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.warning("제보 삭제 실패: %s", e)
+        raise HTTPException(status_code=503, detail="제보 저장소를 사용할 수 없습니다")
+    stat = _apply_overrides_safe() if NET.loaded else {}
+    return {**out, "overrides": stat}
+
+
 # ────────────────────────── admin ──────────────────────────
 @app.post("/admin/reload-network", tags=["admin"], dependencies=[Depends(auth)])
 def reload_network(path: str = Query(None), version: str = Query(None)):

--- a/route_service/collect/store.py
+++ b/route_service/collect/store.py
@@ -234,6 +234,34 @@ class CollectStore:
             raise ValueError("action 은 confirm | reject | apply")
         return {"report_id": report_id, "action": action}
 
+    def delete_report(self, report_id: int) -> dict:
+        """제보 완전 삭제 (v1.17.0) — 오검·중복·시험 제보를 콘솔에서 지우기 위한 것.
+
+        검토(reject)와 다르다. reject 는 '봤고 사실이 아니다'라는 기록을 남기지만,
+        삭제는 기록 자체를 없앤다. 제보에서 파생된 오버라이드도 함께 지운다 —
+        남겨 두면 출처 없는 경고가 그래프에 떠도는 데다, FK 때문에 삭제도 되지 않는다.
+        """
+        rep = self._get_report(report_id)
+        if rep is None:
+            raise KeyError("제보 %s 없음" % report_id)
+
+        if self.backend == "memory":
+            with self._lock:
+                removed = [oid for oid, ov in self._overrides.items()
+                           if ov.get("report_id") == report_id]
+                for oid in removed:
+                    del self._overrides[oid]
+                self._reports.pop(report_id, None)
+            return {"report_id": report_id, "deleted": True,
+                    "deleted_overrides": len(removed)}
+
+        rows = self._exec(
+            "DELETE FROM mv_access_override WHERE report_id = :id RETURNING override_id",
+            {"id": report_id}, fetch=True)
+        self._exec("DELETE FROM mv_access_report WHERE report_id = :id", {"id": report_id})
+        return {"report_id": report_id, "deleted": True,
+                "deleted_overrides": len(rows or [])}
+
     def _get_report(self, report_id: int):
         if self.backend == "memory":
             return self._reports.get(report_id)

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -79,6 +79,45 @@ def test_apply_is_approval_only_and_creates_attr_override():
     assert cs.list_reports()[0]["status"] == "applied"
 
 
+def test_delete_report_removes_record_and_its_overrides():
+    cs = CollectStore()
+    rid = cs.add_report(37.39, 126.9505, "curb", None, None, None, None)["report_id"]
+    assert len(cs.active_overrides()) == 1
+
+    out = cs.delete_report(rid)
+    assert out["deleted"] is True and out["deleted_overrides"] == 1
+    assert cs.list_reports() == []
+    # 기각과 달리 흔적이 남지 않는다 — retired 도 아니고 아예 없다
+    assert cs._overrides == {}
+
+
+def test_delete_report_after_apply_also_drops_attr_override():
+    cs = CollectStore()
+    rid = cs.add_report(37.39, 126.9505, "curb", None, None, None, None)["report_id"]
+    cs.review_report(rid, "apply", attr="curb_cut", value="false")
+    assert len(cs.active_overrides()) == 1
+
+    cs.delete_report(rid)
+    assert cs.active_overrides() == []
+    assert cs.list_reports() == []
+
+
+def test_delete_unknown_report_raises():
+    cs = CollectStore()
+    with pytest.raises(KeyError):
+        cs.delete_report(999)
+
+
+def test_delete_leaves_other_reports_untouched():
+    cs = CollectStore()
+    keep = cs.add_report(37.39, 126.9505, "curb", None, None, None, None)["report_id"]
+    drop = cs.add_report(37.3902, 126.9507, "steep", None, None, None, None)["report_id"]
+    cs.delete_report(drop)
+    ids = [r["report_id"] for r in cs.list_reports()]
+    assert ids == [keep]
+    assert len(cs.active_overrides()) == 1
+
+
 def test_track_log_dedupes_by_seq():
     cs = CollectStore()
     pts = [{"seq": 0, "lat": 37.39, "lng": 126.95},
@@ -207,6 +246,30 @@ def test_collect_api_end_to_end(tmp_path, monkeypatch):
             "profile": "wheelchair_manual"})
         warns = res.json()["routes"][0]["summary"]["warnings"]
         assert not any("이용자 제보" in w for w in warns)
+
+        # 삭제 → 목록에서 사라지고, 남은 오버라이드도 없다 (v1.17.0)
+        res = client.post("/report/accessibility",
+                          json={"lat": 37.3900, "lng": 126.9505, "reason": "blocked"})
+        rid2 = res.json()["report_id"]
+        res = client.post("/route/plan", json={
+            "origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "coord", "lat": 37.3909, "lng": 126.9511},
+            "profile": "wheelchair_manual"})
+        assert any("이용자 제보" in w for w in res.json()["routes"][0]["summary"]["warnings"])
+
+        res = client.delete("/report/accessibility/%d" % rid2)
+        assert res.status_code == 200 and res.json()["deleted"] is True
+        assert all(r["report_id"] != rid2
+                   for r in client.get("/report/accessibility").json()["items"])
+        res = client.post("/route/plan", json={
+            "origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "coord", "lat": 37.3909, "lng": 126.9511},
+            "profile": "wheelchair_manual"})
+        assert not any("이용자 제보" in w
+                       for w in res.json()["routes"][0]["summary"]["warnings"])
+
+        # 없는 제보 삭제는 404
+        assert client.delete("/report/accessibility/99999").status_code == 404
 
         # 트랙 업로드
         res = client.post("/track/log", json={


### PR DESCRIPTION
Closes #47

## 배경

접근성 제보를 지울 수단이 없었다. 오검·중복·실증 리허설의 시험 제보가 목록에 계속 남는다.
기각(`PATCH` `reject`)은 '확인했고 사실이 아님'을 남기는 검토 기록이라 목록 정리 용도로는 맞지 않는다 — 삭제는 기록 자체를 없앤다.

## 변경

| 파일 | 내용 |
|---|---|
| `route_service/collect/store.py` | `delete_report()` — db / memory 백엔드 양쪽 |
| `route_service/api/main.py` | `DELETE /report/accessibility/{report_id}` |
| `README.md` | API 표에 수집 엔드포인트 5종 + 삭제 명시, 버전 v1.17.0 |
| `tests/test_collect.py` | 테스트 5건 |

## 판단 근거

**파생 오버라이드를 함께 지운다.** 제보는 접수 즉시 warning 오버라이드를 자동 생성한다. 제보만 지우면 출처 없는 경고가 그래프에 남아 안내에 계속 뜬다. 게다가 `mv_access_override.report_id` 가 `mv_access_report` 를 참조하는 FK 라 제보 행 삭제 자체가 실패한다.

**retire 가 아니라 삭제다.** 기각은 `status='retired'` 로 이력을 남기지만, 삭제는 그 제보가 없었던 상태로 되돌리는 것이므로 오버라이드 행도 남기지 않는다.

**삭제 즉시 재적용.** `_apply_overrides_safe()` 를 호출해 다음 경로 탐색부터 경고가 걷힌다.

## 검증

- `pytest tests/` — 86 passed
- 신규 5건이 삭제 코드 없이는 실패함을 확인 (메서드·엔드포인트를 비활성화하고 재실행: 5 failed)