### PR TITLE
v1.17.1 릴리즈

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.17.0 |
+| 02-IITP-DABT-Route | v1.17.1 |
 
 ## 구조
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.16.0"
+__version__ = "1.17.1"

--- a/route_service/topomap/crossings.py
+++ b/route_service/topomap/crossings.py
@@ -10,8 +10,8 @@
 대신 보도 **중심선 위의 최근접 지점**으로 투영해 T자 접합을 만들고,
 분할·스냅은 topology.build_topology 가 처리하게 한다.
 
-샌드박스는 overpass 접근이 차단되므로 scripts/fetch_osm_crossings.py 로
-로컬(Windows venv)에서 미리 받아 GeoJSON 으로 넘긴다.
+외부 네트워크 접근이 제한된 환경에서는 scripts/fetch_osm_crossings.py 로
+로컬 실행 환경에서 미리 받아 GeoJSON 으로 넘긴다.
 """
 from __future__ import annotations
 

--- a/scripts/fetch_osm_crossings.py
+++ b/scripts/fetch_osm_crossings.py
@@ -2,7 +2,7 @@
 """OSM 횡단보도 추출 -> GeoJSON.
 
 수치지형도에 횡단보도 레이어가 없어 OSM 기존 데이터로 보완한다.
-인터넷 접근이 필요하므로 로컬 venv 에서 실행한다 (샌드박스는 overpass 차단).
+인터넷 접근이 필요하므로 로컬 venv 에서 실행한다 (외부 네트워크가 제한된 환경에서는 overpass 조회가 불가).
 
   python scripts/fetch_osm_crossings.py \
       --place "Anyang-si, Gyeonggi-do, South Korea" --out data/osm_crossings.geojson

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""버전 표기 정합 검사.
+
+``/health`` 와 OpenAPI 는 ``route_service.__version__`` 을 그대로 보고한다.
+실행 중인 서비스가 어느 배포본인지 판별하는 런타임 근거이므로 레포 버전과
+일치해야 한다.
+
+버전 표기는 소스가 둘(코드 상수와 README)이라 수동으로는 갈라질 수 있다.
+여기서 일치를 고정해 릴리즈 전 검증에서 자동으로 확인되도록 한다.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from route_service import __version__  # noqa: E402
+
+
+def _readme_version() -> str:
+    path = os.path.join(ROOT, "README.md")
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    m = re.search(r"\|\s*02-IITP-DABT-Route\s*\|\s*v(\d+\.\d+\.\d+)\s*\|", text)
+    assert m, "README '## 버전' 표에서 레포 버전을 찾지 못했다"
+    return m.group(1)
+
+
+def test_version_is_semver():
+    """``__version__`` 은 v 접두사 없는 major.minor.patch 형식이다."""
+    assert re.fullmatch(r"\d+\.\d+\.\d+", __version__), (
+        "__version__ 은 major.minor.patch 형식이어야 한다: %r" % __version__)
+
+
+def test_version_matches_readme():
+    """코드 상수와 README 표기가 같아야 한다."""
+    readme = _readme_version()
+    assert __version__ == readme, (
+        "route_service/__init__.py 의 __version__(%s)과 "
+        "README 표기(v%s)가 다르다. 릴리즈 시 두 곳을 함께 갱신한다."
+        % (__version__, readme))


### PR DESCRIPTION
## 배경

두 갈래를 함께 반영한다.

## 변경

**v1.17.1 — 버전 표기 정합 (PR #50)**

| 파일 | 내용 |
|---|---|
| `route_service/__init__.py` | `__version__` 을 v1.17.1 로 정합 |
| `README.md` | `## 버전` 표기 |
| `tests/test_version.py` | 신규 — 표기 일치를 테스트로 고정 |

`/health` 와 OpenAPI 가 이 값을 그대로 보고하므로, 실행 중인 서비스의 배포본 판별 근거가 된다.

**주석의 실행 환경 표현 정리 (PR #51)**

| 파일 | 내용 |
|---|---|
| `route_service/topomap/crossings.py` | overpass 조회 제약 설명을 환경 중립 표현으로 |
| `scripts/fetch_osm_crossings.py` | 동일 |

## 확인

- 점검 도구 재실행 결과 잔존 0건
- 주석 변경분은 동작에 영향 없음