### PR TITLE
v1.18.0 릴리즈

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 스위트케이 (SweetK)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -296,3 +296,10 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 ```bash
 python -m pytest -q
 ```
+
+## 라이선스
+
+이 프로젝트는 MIT 라이선스로 배포됩니다. 전문은 [LICENSE](LICENSE) 파일을 참고하십시오.
+
+본 연구는 정부(과학기술정보통신부)의 재원으로 정보통신기획평가원의 지원을 받아 수행된 연구입니다.
+(연구개발과제번호 RS-2024-003976, 데이터 기반 장애인 데이터 탐색·활용 해결기술 개발)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.17.1 |
+| 02-IITP-DABT-Route | v1.18.0 |
 
 ## 구조
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.17.1"
+__version__ = "1.18.0"

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -158,6 +158,16 @@ def _resolve_destination(dest: Destination, profile, allowed=None) -> dict:
             raise HTTPException(status_code=400, detail="목적지 좌표가 없습니다")
         return {"lat": dest.lat, "lng": dest.lng, "source": "coord"}
 
+    if dest.type == "building":
+        # 이름으로 찾은 일반 시설 — 좌표가 건물 대표점이므로 출입구 해석을 거친다.
+        # coord 와 달리 "이용자가 지도에서 콕 집은 점"이 아니라 "시설"이기 때문이다.
+        if dest.lat is None or dest.lng is None:
+            raise HTTPException(status_code=400, detail="목적지 좌표가 없습니다")
+        return resolve_access_point(
+            NET, dest.lat, dest.lng, profile, BUILDINGS,
+            max_walk_m=settings.entrance_max_walk_m, allowed=allowed,
+        )
+
     if not dest.poi_id:
         raise HTTPException(status_code=400, detail="poi_id 가 필요합니다")
 
@@ -587,6 +597,90 @@ def route_get(route_id: str):
     if payload is None:
         raise HTTPException(status_code=404, detail="경로를 찾을 수 없습니다(만료되었을 수 있음)")
     return payload
+
+
+# ────────────────────────── poi 검색 ──────────────────────────
+def _in_bbox(lat, lng) -> bool:
+    """서비스 네트워크 bbox 안인지. 네트워크가 없으면 판정하지 않는다(True)."""
+    if not NET.loaded:
+        return True
+    bb = (NET.meta or {}).get("bbox") or {}
+    if bb.get("min_lat") is None:
+        return True
+    return (bb["min_lat"] <= lat <= bb["max_lat"]
+            and bb["min_lng"] <= lng <= bb["max_lng"])
+
+
+_SEARCH_TYPE_ORDER = {"tour": 0, "transit_station": 1, "building": 2}
+
+
+@app.get("/poi/search", tags=["poi"], dependencies=[Depends(auth)])
+def poi_search(
+    q: str = Query(..., min_length=1, description="장소 이름. 예: '안양시청', '노인종합복지관'"),
+    sigungu: str = Query("안양", description="관광 POI 주소 필터"),
+    limit: int = Query(8, ge=1, le=30),
+    include_outside: bool = Query(
+        False, description="서비스 범위 밖 결과도 in_service_area=false 로 함께 준다"),
+):
+    """이름으로 장소를 찾아 좌표를 돌려준다 (v1.18.0).
+
+    관광지·지하철역만으로는 이용자가 말하는 목적지(시청·복지관·도서관·학교·병원)를
+    좌표로 바꿀 수 없어, 서비스 지역 안의 장소가 "지역 밖"으로 잘못 안내됐다.
+    건물 폴리곤 이름(OSM)을 세 번째 출처로 더해 그 공백을 메운다.
+
+    ``type`` 별 목적지 지정 방법:
+      - ``tour``            -> ``{"type": "tour", "poi_id": ...}``
+      - ``transit_station`` -> ``{"type": "transit_station", "poi_id": ...}``
+      - ``building``        -> ``{"type": "building", "lat": ..., "lng": ...}``
+        (건물 접근점 해석을 거치므로 좌표를 그대로 쓰는 ``coord`` 보다 낫다)
+    """
+    items = []
+    try:
+        items.extend(poi_store.STORE.search_tour_by_name(q, sigungu=sigungu, limit=limit))
+    except Exception as e:                       # POI DB 미가용 — 나머지 출처로 계속
+        logger.warning("관광 POI 이름 검색 실패(%s) — 건물·역 결과만 제공", e)
+    try:
+        items.extend(poi_store.STORE.search_stations_by_name(q, limit=limit))
+    except Exception as e:
+        logger.warning("역 이름 검색 실패(%s)", e)
+    items.extend(BUILDINGS.search_by_name(q, limit=limit))
+
+    out, seen = [], set()
+    for it in items:
+        lat, lng = it.get("lat"), it.get("lng")
+        if lat is None or lng is None:
+            continue
+        inside = _in_bbox(lat, lng)
+        # 범위 밖 결과를 그냥 버리면 소비 측은 "찾지 못했다"와 "범위 밖이다"를 구분할 수
+        # 없다. 둘은 이용자에게 다르게 들려야 하는 사유이므로 표시해서 돌려준다.
+        if not inside and not include_outside:
+            continue
+        key = (it.get("type"), str(it.get("poi_id") or ""), round(lat, 5), round(lng, 5))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({
+            "type": it.get("type") or "tour",
+            "poi_id": it.get("poi_id"),
+            "name": it.get("name"),
+            "addr": it.get("addr"),
+            "lat": lat, "lng": lng,
+            "facilities": it.get("facilities"),
+            "in_service_area": inside,
+            "match_rank": it.get("match_rank", 9),
+        })
+    # 범위 안 결과를 항상 앞세운다 — 밖의 결과는 "왜 안 되는지" 를 말하기 위한 근거일 뿐이다
+    out.sort(key=lambda x: (not x["in_service_area"], x["match_rank"],
+                            _SEARCH_TYPE_ORDER.get(x["type"], 9),
+                            len(x["name"] or ""), x["name"] or ""))
+    return {
+        "query": q,
+        "region": (NET.meta or {}).get("region") if NET.loaded else settings.region_name,
+        "source": poi_store.STORE.source,
+        "buildings_loaded": bool(BUILDINGS.loaded),
+        "count": len(out[:limit]),
+        "items": out[:limit],
+    }
 
 
 # ────────────────────────── tour ──────────────────────────

--- a/route_service/api/schemas.py
+++ b/route_service/api/schemas.py
@@ -20,9 +20,13 @@ class Coord(BaseModel):
 
 
 class Destination(BaseModel):
-    """좌표 직접 지정 또는 POI 지정(무장애 관광지 / 대중교통 접근점)."""
+    """좌표 직접 지정 또는 POI 지정(무장애 관광지 / 대중교통 접근점 / 이름으로 찾은 건물).
 
-    type: str = Field("coord", description="coord | tour | transit_stop | transit_station")
+    ``coord`` 는 이용자가 지도에서 직접 집은 점이라 그대로 쓰고, ``building`` 은
+    ``/poi/search`` 가 돌려준 건물 대표점이라 출입구 접근점 해석을 거친다.
+    """
+
+    type: str = Field("coord", description="coord | tour | building | transit_stop | transit_station")
     poi_id: Optional[str] = None
     lat: Optional[float] = None
     lng: Optional[float] = None

--- a/route_service/engine/access.py
+++ b/route_service/engine/access.py
@@ -25,6 +25,7 @@ import logging
 import math
 import os
 import pickle
+import re
 
 from .geo import haversine_m
 from .snap import snap
@@ -38,6 +39,7 @@ class BuildingIndex:
     def __init__(self, path: str = ""):
         self.polys = []          # [(shapely Polygon, name)]
         self.loaded = False
+        self._names = None       # 이름 검색 인덱스 (지연 생성)
         if path and os.path.exists(path):
             try:
                 self.load(path)
@@ -51,6 +53,65 @@ class BuildingIndex:
             self.polys = pickle.load(f)
         self.loaded = True
         return len(self.polys)
+
+    # ── 이름으로 장소 찾기 (v1.18.0) ──
+    # 건물 폴리곤에는 OSM 이름이 함께 들어 있다(안양 9,563동 중 2,032동이 이름 보유).
+    # 관광지·역이 아닌 일반 시설 — 시청·구청·복지관·도서관·학교·병원 — 은 이 이름이
+    # 유일한 좌표 출처다. 이 인덱스가 없으면 이용자가 말한 목적지를 좌표로 바꿀 방법이
+    # 없어 "서비스 지역 밖"으로 잘못 안내된다(12번 실사용 결함).
+    @staticmethod
+    def _norm(s: str) -> str:
+        return re.sub(r"[\s\-_·.,()]+", "", str(s or ""))
+
+    def _name_index(self) -> list:
+        """[(name, norm_name, lat, lng)] — 대표점은 폴리곤 내부가 보장되는 점을 쓴다."""
+        if self._names is not None:
+            return self._names
+        idx = []
+        if self.loaded:
+            seen = set()
+            for poly, name in self.polys:
+                if not name or not str(name).strip():
+                    continue
+                try:
+                    pt = poly.representative_point()
+                except Exception:
+                    continue
+                lat, lng = round(pt.y, 7), round(pt.x, 7)
+                key = (self._norm(name), round(lat, 4), round(lng, 4))
+                if key in seen:          # 같은 시설의 분할 폴리곤 중복 제거
+                    continue
+                seen.add(key)
+                idx.append((str(name).strip(), self._norm(name), lat, lng))
+        self._names = idx
+        return idx
+
+    def search_by_name(self, q: str, limit: int = 8) -> list:
+        """이름으로 건물을 찾는다 — 완전일치 > 접두 > 부분일치 순.
+
+        질의가 이름을 포함하는 역방향 일치("안양시청 민원실" -> "안양시청")도 허용하되,
+        두 글자 이하 이름은 오탐이 많아(예: "역") 역방향 대상에서 제외한다.
+        """
+        nq = self._norm(q)
+        if len(nq) < 2:
+            return []
+        hits = []
+        for name, nname, lat, lng in self._name_index():
+            if nname == nq:
+                rank = 0
+            elif nname.startswith(nq):
+                rank = 1
+            elif nq in nname:
+                rank = 2
+            elif len(nname) >= 3 and nname in nq:
+                rank = 3
+            else:
+                continue
+            hits.append((rank, len(nname), name, lat, lng))
+        hits.sort(key=lambda x: (x[0], x[1], x[2]))
+        return [{"type": "building", "poi_id": None, "name": nm,
+                 "lat": la, "lng": ln, "match_rank": rk}
+                for rk, _l, nm, la, ln in hits[:limit]]
 
     def containing(self, lat: float, lng: float, near_m: float = 40.0):
         """점을 포함하는 건물. 없으면 near_m 이내 최근접 건물.

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 
 from ..engine.geo import haversine_m
 
@@ -151,6 +152,27 @@ def _addr_in_sigungu(addr: str, variants: list) -> bool:
     return any(v in a for v in variants)
 
 
+def _norm_name(s: str) -> str:
+    """이름 대조용 정규화 — 공백·가운뎃점·괄호류 제거."""
+    return re.sub(r"[\s\-_·.,()]+", "", str(s or ""))
+
+
+def _name_match_rank(nq: str, name: str):
+    """완전일치 0 / 접두 1 / 부분 2 / 역방향 3 — 매칭 실패는 None."""
+    nn = _norm_name(name)
+    if not nn or not nq:
+        return None
+    if nn == nq:
+        return 0
+    if nn.startswith(nq):
+        return 1
+    if nq in nn:
+        return 2
+    if len(nn) >= 3 and nn in nq:
+        return 3
+    return None
+
+
 class PoiStore:
     def __init__(self, backend: str = "none", data_dir: str = "", dsn: str = ""):
         self.backend = backend
@@ -273,6 +295,83 @@ class PoiStore:
             "facilities": fac,
             "entrance": r.get("entrance"),
         }
+
+    def search_tour_by_name(self, q: str, sigungu: str = "", limit: int = 10) -> list:
+        """이름으로 관광 POI 를 찾는다 (v1.18.0).
+
+        ``list_tour_spots`` 는 ``accessible_facilities`` 가 채워진 행만 본다 — 무장애
+        관광지 목록이라는 용도에는 맞지만, 이용자가 말한 목적지를 좌표로 바꾸는
+        용도로는 지나치게 좁다. 이름 검색은 그 필터 없이 전체 mv_poi 를 대상으로 하되
+        지역(시·군·구) 조건은 그대로 지킨다(#26 의 "안양면" 오탐 방지).
+        """
+        key = _norm_name(q)
+        if len(key) < 2:
+            return []
+        if self.backend == "none":
+            return []
+        if self.backend == "file":
+            rows = self._load_file("tour_bf.json")
+        else:
+            variants = sigungu_variants(sigungu)
+            params = {"limit": max(limit * 20, 100), "q": "%%%s%%" % q.strip()}
+            sg_clause = ""
+            if variants:
+                ors = []
+                for i, v in enumerate(variants):
+                    ors.append(
+                        "COALESCE(address_road, '') LIKE '%%' || :sg{0} || '%%'"
+                        " OR COALESCE(address_detail, '') LIKE '%%' || :sg{0} || '%%'".format(i)
+                    )
+                    params["sg%d" % i] = v
+                sg_clause = "AND (%s)" % " OR ".join(ors)
+            rows = self._query(
+                """
+                SELECT poi_id,
+                       title AS name,
+                       COALESCE(address_road, address_detail) AS addr,
+                       latitude, longitude,
+                       detail_json->>'accessible_facilities' AS fac_text,
+                       search_filter_json->'search_filter'->>'tourist_type' AS tourist_type
+                  FROM mv_poi
+                 WHERE language_code = 'ko'
+                   AND latitude IS NOT NULL AND longitude IS NOT NULL
+                   AND title ILIKE :q
+                   {sg}
+                 LIMIT :limit
+                """.format(sg=sg_clause),
+                params,
+            )
+        out = []
+        for r in rows:
+            item = self._normalize_tour(r)
+            if item["lat"] is None:
+                continue
+            rank = _name_match_rank(key, item.get("name"))
+            if rank is None:
+                continue
+            item["match_rank"] = rank
+            out.append(item)
+        out.sort(key=lambda x: (x["match_rank"], len(x.get("name") or ""), x.get("name") or ""))
+        return out[:limit]
+
+    def search_stations_by_name(self, q: str, limit: int = 5) -> list:
+        """이름으로 지하철역을 찾는다 — "안양역", "범계" 모두 매칭."""
+        key = _norm_name(q)
+        if len(key) < 1:
+            return []
+        key = key[:-1] if key.endswith("역") and len(key) > 1 else key
+        out = []
+        for st in self._stations():
+            if st["lat"] is None:
+                continue
+            rank = _name_match_rank(key, st.get("name"))
+            if rank is None:
+                continue
+            item = dict(st)
+            item.update({"type": "transit_station", "match_rank": rank})
+            out.append(item)
+        out.sort(key=lambda x: (x["match_rank"], x.get("name") or ""))
+        return out[:limit]
 
     def get_tour_spot(self, poi_id: str):
         """ID 우선, 실패하면 이름으로도 찾는다.

--- a/tests/test_poi_search.py
+++ b/tests/test_poi_search.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+"""이름으로 장소 찾기 — /poi/search 와 그 세 출처.
+
+관광지·지하철역만으로는 이용자가 말하는 목적지(시청·복지관·도서관)를 좌표로 바꿀 수
+없어, 서비스 지역 안의 장소가 "지역 밖"으로 잘못 안내됐다. 건물 폴리곤 이름을 세 번째
+출처로 더한 것이 이 검사의 대상이다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from route_service.engine.access import BuildingIndex  # noqa: E402
+from route_service.poi.store import PoiStore  # noqa: E402
+
+from test_api import client  # noqa: E402,F401  (픽스처 재사용)
+
+
+# ── 건물 이름 인덱스 ──
+def _index(names_and_boxes):
+    shapely = pytest.importorskip("shapely")
+    from shapely.geometry import box
+
+    idx = BuildingIndex()
+    idx.polys = [(box(lng, lat, lng + 0.0005, lat + 0.0005), nm)
+                 for nm, lat, lng in names_and_boxes]
+    idx.loaded = True
+    return idx
+
+
+BUILDINGS = [
+    ("안양시청", 37.3943, 126.9568),
+    ("안양시노인종합복지관", 37.4000, 126.9300),
+    ("안양시 노인종합복지회관", 37.4010, 126.9310),
+    ("평촌도서관", 37.3940, 126.9640),
+    ("체육관", 37.3900, 126.9500),
+]
+
+
+def test_building_exact_match_ranks_first():
+    idx = _index(BUILDINGS)
+    hits = idx.search_by_name("안양시청")
+    assert hits and hits[0]["name"] == "안양시청"
+    assert hits[0]["type"] == "building" and hits[0]["match_rank"] == 0
+    # 대표점은 폴리곤 내부 좌표여야 한다 (스냅 대상이 되므로)
+    assert 37.394 <= hits[0]["lat"] <= 37.395
+
+
+def test_building_space_insensitive_match():
+    """'노인종합복지관' 은 띄어쓰기가 다른 표기와도 매칭돼야 한다."""
+    idx = _index(BUILDINGS)
+    names = [h["name"] for h in idx.search_by_name("노인종합복지관")]
+    assert "안양시노인종합복지관" in names
+
+
+def test_building_reverse_match_allows_suffix():
+    """'안양시청 민원실' 처럼 질의가 이름을 포함하는 경우도 찾는다."""
+    idx = _index(BUILDINGS)
+    hits = idx.search_by_name("안양시청 민원실")
+    assert hits and hits[0]["name"] == "안양시청"
+
+
+def test_building_short_query_rejected():
+    """한 글자 질의는 오탐이 너무 많아 검색하지 않는다."""
+    assert _index(BUILDINGS).search_by_name("관") == []
+
+
+def test_building_index_empty_when_not_loaded():
+    assert BuildingIndex().search_by_name("안양시청") == []
+
+
+# ── 관광 POI 이름 검색 ──
+class _RecordingStore(PoiStore):
+    def __init__(self, rows):
+        super().__init__(backend="db", dsn="postgresql+psycopg2://x/y")
+        self._rows = rows
+        self.last_sql = None
+        self.last_params = None
+
+    def _query(self, sql, params):
+        self.last_sql = sql
+        self.last_params = params
+        return self._rows
+
+
+TOUR_ROW = {
+    "poi_id": 991, "name": "안양예술공원",
+    "addr": "경기도 안양시 만안구 예술공원로 180",
+    "latitude": 37.4020, "longitude": 126.9210,
+    "fac_text": "", "tourist_type": None,
+}
+
+
+def test_tour_name_search_drops_facility_filter():
+    """이름 검색은 무장애 시설 정보가 비어 있는 POI 도 찾아야 한다.
+
+    목록(list_tour_spots)의 accessible_facilities 조건을 그대로 쓰면
+    좌표 해석 용도로는 지나치게 좁다.
+    """
+    store = _RecordingStore([TOUR_ROW])
+    out = store.search_tour_by_name("안양예술공원", sigungu="안양")
+    assert len(out) == 1 and out[0]["poi_id"] == "991"
+    assert "COALESCE(detail_json->>'accessible_facilities', '') <> ''" not in store.last_sql
+    assert "ILIKE" in store.last_sql
+    # 지역 조건은 유지된다 (#26 타지역 '안양면' 오탐 방지)
+    assert store.last_params["sg0"] == "안양시"
+
+
+def test_tour_name_search_short_query_rejected():
+    store = _RecordingStore([TOUR_ROW])
+    assert store.search_tour_by_name("안") == []
+    assert store.last_sql is None      # 질의 자체를 보내지 않는다
+
+
+def test_station_name_search_strips_suffix():
+    store = PoiStore(backend="file", data_dir="")
+    store._cache["stations.json"] = [
+        {"poi_id": "S1", "name": "범계", "latitude": 37.3899, "longitude": 126.9509,
+         "elevator_cnt": 2, "wheelchair_lift_cnt": 0},
+        {"poi_id": "S2", "name": "평촌", "latitude": 37.3942, "longitude": 126.9638,
+         "elevator_cnt": 1, "wheelchair_lift_cnt": 0},
+    ]
+    out = store.search_stations_by_name("범계역")
+    assert len(out) == 1 and out[0]["name"] == "범계"
+    assert out[0]["type"] == "transit_station"
+
+
+# ── 엔드포인트 ──
+def test_poi_search_endpoint_finds_tour_and_station(client):
+    body = client.get("/poi/search", params={"q": "테스트역"}).json()
+    names = [i["name"] for i in body["items"]]
+    assert "테스트역" in names
+    assert body["region"] == "안양시"
+
+    body = client.get("/poi/search", params={"q": "무장애 공원"}).json()
+    assert any(i["type"] == "tour" and i["poi_id"] == "TBF-1" for i in body["items"])
+
+
+def test_poi_search_filters_out_of_bbox(client):
+    """네트워크 bbox 밖 좌표는 결과에서 제외된다 — 경로를 만들 수 없기 때문."""
+    import route_service.api.main as m
+
+    far = m.poi_store.STORE
+    far._cache["stations.json"] = list(far._load_file("stations.json")) + [
+        {"poi_id": "S9", "name": "서울역", "latitude": 37.5547, "longitude": 126.9707,
+         "elevator_cnt": 5, "wheelchair_lift_cnt": 0},
+    ]
+    body = client.get("/poi/search", params={"q": "서울역"}).json()
+    assert body["items"] == []
+
+
+def test_poi_search_include_outside_flags_instead_of_dropping(client):
+    """범위 밖 결과를 버리면 소비 측이 '못 찾음'과 '범위 밖'을 구분할 수 없다."""
+    import route_service.api.main as m
+
+    st = m.poi_store.STORE
+    st._cache["stations.json"] = list(st._load_file("stations.json")) + [
+        {"poi_id": "S9", "name": "서울역", "latitude": 37.5547, "longitude": 126.9707,
+         "elevator_cnt": 5, "wheelchair_lift_cnt": 0},
+    ]
+    body = client.get("/poi/search",
+                      params={"q": "서울역", "include_outside": "true"}).json()
+    assert body["count"] == 1
+    assert body["items"][0]["in_service_area"] is False
+
+
+def test_poi_search_puts_in_area_results_first(client):
+    """범위 밖 항목은 사유 설명용일 뿐 — 범위 안 결과를 밀어내면 안 된다."""
+    import route_service.api.main as m
+
+    st = m.poi_store.STORE
+    st._cache["stations.json"] = list(st._load_file("stations.json")) + [
+        {"poi_id": "S8", "name": "테스트역앞", "latitude": 37.5548, "longitude": 126.9708,
+         "elevator_cnt": 1, "wheelchair_lift_cnt": 0},
+    ]
+    body = client.get("/poi/search",
+                      params={"q": "테스트역", "include_outside": "true"}).json()
+    assert body["items"][0]["in_service_area"] is True
+    assert body["items"][0]["name"] == "테스트역"
+
+
+def test_poi_search_empty_for_unknown_place(client):
+    body = client.get("/poi/search", params={"q": "존재하지않는장소이름"}).json()
+    assert body["count"] == 0 and body["items"] == []
+
+
+def test_plan_to_building_destination_resolves_access_point(client):
+    """building 목적지는 좌표를 그대로 쓰지 않고 접근점 해석을 거친다."""
+    r = client.post(
+        "/route/plan",
+        json={
+            "origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "building", "lat": 37.3909, "lng": 126.9511},
+            "profile": "wheelchair_manual",
+        },
+    )
+    assert r.status_code == 200
+    dest = r.json()["destination"]
+    assert dest["type"] == "building"
+    # 건물 폴리곤이 없는 테스트 환경에서는 대표점으로 떨어지되, coord 와 구분된다
+    assert dest["resolved_by"] in ("building_access", "facility_centroid")
+
+
+def test_plan_building_without_coord_is_400(client):
+    r = client.post(
+        "/route/plan",
+        json={
+            "origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "building"},
+            "profile": "wheelchair_manual",
+        },
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## 릴리즈 요약

이름으로 장소를 찾는 조회 수단을 추가했습니다. 종전에는 목적지로 지정할 수 있는 대상이 무장애 관광지와 대중교통 접근점, 그리고 호출자가 직접 계산한 좌표뿐이어서, 시청·구청·복지관·도서관 같은 일반 시설은 서비스 지역 안에 있어도 경로를 만들 수 없었습니다.

- `GET /poi/search` 신설 — 관광 POI · 지하철역 · 건물 이름 통합 조회
- 접근점 해석용으로 이미 적재하던 건물 폴리곤 중 **이름을 가진 2,032동**을 세 번째 좌표 출처로 활용
- 보행망 bbox 밖 결과는 버리지 않고 `in_service_area=false` 로 표시해 반환 — 소비 측이 "이름을 찾지 못함"과 "서비스 지역 밖"을 구분해 안내할 수 있게 함
- 목적지 타입 `building` 추가 — 기존 출입구 접근점 해석을 거침

## 포함된 작업 PR

- #54 v1.18.0 — 이름으로 장소를 찾는 조회 수단 추가 (관광지·역·건물 통합 검색)
- 라이선스 표기 · 연구개발과제 사사 표기 정리 (문서)

## 검증

`python3 -m pytest -q` 112건 전건 통과 (신규 15건 포함). 실데이터 확인 — 안양시청 → 평촌도서관 302m, `resolved_by=building_access`.

## 해결된 이슈

Closes #53