### PR TITLE
v1.19.0 - 실시간 저상버스 도착·위치 조회와 역 편의시설 설비 단위 조회

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ ROUTE_API_TOKEN=
 ALLOWED_ORIGINS=http://127.0.0.1:18000,http://localhost:18000
 SNAP_MAX_DIST_M=300
 OFF_ROUTE_THRESHOLD_M=30
+
+# 실시간 버스(GBIS) — 공공데이터포털 일반 인증키 하나로 도착·위치 API 모두 호출
+# (경기도_버스도착정보 조회 15080346 / 경기도_버스위치정보 조회 15080648 활용신청 필요)
+DATA_GO_KR_API_KEY=
+GBIS_BASE_URL=https://apis.data.go.kr/6410000
+GBIS_TIMEOUT_SEC=3
+GBIS_CACHE_TTL_SEC=20

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.18.0 |
+| 02-IITP-DABT-Route | v1.19.0 |
 
 ## 구조
 
@@ -132,7 +132,10 @@ curl -s localhost:18100/meta/network
 | GET | `/tour/bf-spots/{id}` | 관광지 상세 (편의시설 Y/N) |
 | GET | `/tour/bf-spots/{id}/entrance` | **무장애 접근 지점** — 실측 출입구 > 건물 접근점 > 시설 대표점 |
 | POST | `/tour/recommend` | 장애 유형별 관광지 추천 랭킹 — `origin_lat/lng` 지정 시 **거리 오름차순**, `offset` 페이징(`total`/`has_more` 반환) |
-| GET | `/transit/access-points` | 휠체어 접근 가능한 정류장·역 |
+| GET | `/transit/access-points` | 휠체어 접근 가능한 정류장·역 (역 화장실·경사로 유무는 3상태) |
+| GET | `/transit/bus/arrivals` | **정류장 실시간 도착정보** — 노선별 1·2번째 차량의 도착 예정·정거장 수·**저상 여부**, `next_low_floor` |
+| GET | `/transit/bus/locations` | **노선 실시간 차량 위치** — 운행 차량의 현재 정류장(좌표 조인)·저상 여부 |
+| GET | `/transit/station/facilities` | **역 편의시설(설비 단위)** — 승강기·리프트 출입구/상세위치, 화장실(게이트 안/밖), 승강장(안전발판·이격거리) |
 | POST | `/track/log` | 주행 GPS 트랙 적재 (참여자 식별자 없음 — `route_id` 익명) |
 | POST | `/report/accessibility` | 접근성 오류 제보 — 접수 즉시 '이용자 제보(미확인)' 경고 부착 |
 | GET | `/report/accessibility` | 제보 목록 (관리 콘솔용) |
@@ -227,8 +230,33 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 보행 경로를 제공한다.
 
 - 목적지 유형 `transit_station`: 지하철역 — 승강설비(엘리베이터/리프트) 보유 여부로 접근성 판정
-- 목적지 유형 `transit_stop`: 버스 정류장 — 저상버스 정차 여부는 정적 데이터에 없으므로
-  실시간 도착정보(GBIS `lowPlate`)로 확인해야 한다
+- 목적지 유형 `transit_stop`: 버스 정류장 — 저상버스 정차 여부는 정적 데이터에 없다.
+  **v1.19.0 부터 실시간 도착정보(GBIS `lowPlate`)를 서비스가 직접 조회한다** — 아래 "실시간 버스" 참고
+
+### 실시간 버스 (v1.19.0)
+
+경기버스정보(GBIS) 공공데이터포털 API 두 종을 `DATA_GO_KR_API_KEY` 하나로 호출한다.
+
+| 엔드포인트 | 원천 | 쓰임 |
+|---|---|---|
+| `GET /transit/bus/arrivals?station_id=&route_id=` | 버스도착정보 조회(`getBusArrivalListv2`) | 승차 정류장에 오는 노선별 1·2번째 차량의 도착 예정(분)·몇 정거장 전·**저상 여부**. `next_low_floor` = 가장 빨리 오는 저상 차량 |
+| `GET /transit/bus/locations?route_id=` | 버스위치정보 조회(`getBusLocationListv2`) | 노선 전 차량의 현재 정류장 순번·저상 여부. 정적 경유정류소와 조인해 좌표를 붙인다 |
+| `POST /route/plan` + `realtime: true` | 위 도착정보 | 버스 leg 의 승차 정류장 도착정보를 `legs[].realtime` 에 싣고, 저상 차량이 확인되면 고정 경고를 실측 문구로 바꾼다 |
+
+- 실시간 조회 실패는 `status: unavailable` 로 답하고 **경로 안내는 막지 않는다**(고정 경고 유지).
+- 같은 정류장·노선의 반복 폴링은 20초 TTL 캐시로 흡수한다(`GBIS_CACHE_TTL_SEC`). 개발계정 도착정보 한도는 1,000회/일이다.
+- `next_low_floor` 가 `null` 인 것은 "저상버스가 없다"가 아니라 "도착정보에 잡힌 두 대 안에는 없다"는 뜻이다. 3번째 이후 차량은 위치정보로 본다.
+- 스텝(`bus_board`/`bus_alight`)에 `leg_ref{route_id, board_station_id, alight_station_id}` 가 실린다 — 클라이언트가 안내 중 폴링할 키다.
+
+### 역 편의시설 — 설비 단위 (v1.19.0)
+
+`poi_station_access_status` 는 역별 **개수·유무**뿐이었다. 국가철도공단 파일(01 v1.3.0 테이블 3종
+`poi_station_elevator_unit` / `poi_station_toilet_unit` / `poi_station_platform` + 기존 `poi_station_wheelchair_lift`)을
+붙여 `GET /transit/station/facilities?name=범계역` 이 **어느 출입구의 엘리베이터인지, 장애인화장실이 게이트 안인지 밖인지,
+승강장에 안전발판이 있는지, 열차와의 이격거리가 몇 cm 인지**까지 답한다. 지하철 leg 의 `board`/`alight` 에도 요약(`facilities`)이 붙는다.
+
+유무 필드는 **3상태**(`yes` / `no` / `unknown`)다. 코레일 편의시설 API 는 안양역만 응답하고 나머지 6역은 `NULL` 이라,
+`unknown` 을 "없음"으로 말하면 틀린다. 실시간 승강기 가동 여부는 코레일이 제공하지 않아 싣지 않는다.
 
 ### 접근성 판정은 3상태다
 
@@ -270,7 +298,7 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 | 보행 네트워크 | **OSM 안양 보행망** — 노드 6,750 / 링크 9,712 | 원본(node/link) 수령 시 `--source tabular` 로 재구축 후 `/admin/reload-network` — API 스키마 불변 |
 | 경사 | **5m DEM** — 1:5,000 수치지형도 등고선(주곡선 5m)을 보간해 생성 (`scripts/dem_from_contours.py`) | 공개DEM 90m(`.img`)도 그대로 사용 가능. DEM 이 아예 없으면 `--elevation terrain`(공개 지형 타일, 인증 불필요) |
 | 무장애 관광지 | 01-IITP-DABT-Database `mv_poi` 정본 (`POI_BACKEND=db`) — 한국어 시설 문구를 `*_yn` 체계로 정규화(`MVPOI_FACILITY_MAP`), **안양 31건 실측** | 08 파이프라인이 수집·적재. 적재 전에는 `file`/`none` 백엔드로 기동 가능 |
-| 역·정류장 | `poi_station_access_status` 등 — **미적재** | 적재 전까지 `/transit/access-points` 는 빈 결과 |
+| 역·정류장 | `poi_station_access_status` 412역(안양 7역) + `tran_bus_station_info` 3,496 + 설비 단위 3종(v1.19.0) | 실시간 저상 여부는 GBIS 도착·위치 API |
 
 ### 안양 그래프 실측 (v1.3.0)
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -27,6 +27,7 @@ from ..engine.steps import build_steps
 from ..collect import store as collect_store
 from ..engine.overrides import apply_overrides
 from ..poi import store as poi_store
+from ..transit import gbis_live
 from ..transit import planner as transit
 from .schemas import (
     AccessReportRequest,
@@ -57,6 +58,8 @@ def _apply_overrides_safe() -> dict:
 async def lifespan(_app: FastAPI):
     poi_store.configure(settings)
     collect_store.configure(settings)
+    gbis_live.LIVE = gbis_live.configure(settings)
+    logger.info("GBIS 실시간: %s", "사용" if gbis_live.LIVE.enabled else "인증키 없음(비활성)")
     global BUILDINGS, ENTRANCES
     BUILDINGS = BuildingIndex(settings.buildings_path)
     ENTRANCES = ManualEntrances(settings.entrances_path)
@@ -124,6 +127,7 @@ def health():
         "version": __version__,
         "graph_loaded": NET.loaded,
         "poi_backend": poi_store.STORE.source,
+        "bus_realtime": gbis_live.LIVE.enabled,
     }
 
 
@@ -342,7 +346,7 @@ def _bus_leg(part):
                 "center_yn": bool(s.get("center_yn"))}
     return {
         "kind": "bus",
-        "route": {"route_id": route["route_id"], "name": route.get("name"),
+        "route": {"route_id": str(route["route_id"]), "name": route.get("name"),
                   "type": route.get("type"), "end_station": route.get("end_station")},
         "board": _stop(part["board"], part["seq_from"]),
         "alight": _stop(part["alight"], part["seq_to"]),
@@ -409,16 +413,85 @@ def _transit_step(leg, boarding: bool) -> dict:
             instruction = "%s역에서 하차합니다" % leg["alight"]["name"]
             coord = [leg["alight"]["lat"], leg["alight"]["lng"]]
             maneuver = "subway_alight"
+    leg_ref = {"kind": leg["kind"]}
+    if leg["kind"] == "bus":
+        leg_ref.update({"route_id": str(leg["route"]["route_id"]),
+                        "route_name": leg["route"].get("name"),
+                        "board_station_id": str(leg["board"]["poi_id"]),
+                        "board_name": leg["board"]["name"],
+                        "alight_station_id": str(leg["alight"]["poi_id"])})
+    else:
+        leg_ref.update({"line": leg.get("line"),
+                        "board_station_id": str(leg["board"]["poi_id"]),
+                        "alight_station_id": str(leg["alight"]["poi_id"])})
     return {"maneuver": maneuver, "instruction": instruction,
             "distance_m": 0 if not boarding else leg["est_distance_m"],
             "duration_sec": 0 if not boarding else leg["est_duration_sec"],
             "coord": [round(coord[0], 7), round(coord[1], 7)],
             "link_type": leg["kind"], "link_name": None,
+            "leg_ref": leg_ref,
             "warnings": leg["warnings"] if boarding else []}
 
 
+def _station_brief(poi_id: str, name: str) -> dict:
+    """지하철 leg 승·하차 역의 설비 요약 — 승강기 출입구·리프트·장애인화장실(3상태)."""
+    try:
+        fac = poi_store.STORE.station_facilities(stn_cd=poi_id, name=name)
+    except Exception as e:
+        logger.warning("역 설비 조회 실패 %s: %s", name, e)
+        fac = None
+    if not fac:
+        return {}
+    return {
+        "elevators": [{"exit_no": e["exit_no"], "detail_loc": e["detail_loc"]}
+                      for e in fac["elevators"][:6]],
+        "lifts": [{"exit_no": l["exit_no"], "detail_loc": l["detail_loc"]} for l in fac["lifts"][:4]],
+        "dis_toilet": fac["status"]["dis_toilet"],
+        "safety_plate": fac["status"]["safety_plate"],
+        "elevator_cnt": fac["counts"]["elevator"],
+        "wheelchair_lift_cnt": fac["counts"]["wheelchair_lift"],
+    }
+
+
+def _attach_realtime(legs: list, realtime: bool) -> None:
+    """최종 선택된 legs 에 실시간·설비 정보를 붙인다.
+
+    - 버스: realtime=true 면 승차 정류장 도착정보(해당 노선만) — 저상 차량이 확인되면
+      고정 경고(LOW_BUS_WARNING)를 실측 문구로 바꾼다. 실패하면 경고를 그대로 둔다.
+    - 지하철: 승·하차 역 설비 요약(정적) — 항상 붙인다(자료 없으면 빈 dict).
+    """
+    for leg in legs:
+        if leg["kind"] == "bus":
+            if not realtime:
+                continue
+            board = leg["board"]
+            rid = leg["route"]["route_id"]
+            try:
+                meta = poi_store.STORE.stop_route_meta(board["poi_id"])
+            except Exception:
+                meta = {}
+            live = gbis_live.LIVE.arrivals(board["poi_id"], route_id=rid, route_meta=meta)
+            leg["realtime"] = live
+            nlf = live.get("next_low_floor")
+            if live.get("status") == "success":
+                if nlf:
+                    leg["warnings"] = [w for w in leg["warnings"] if w != LOW_BUS_WARNING]
+                    leg["warnings"].insert(0, "저상버스 %s번이 약 %d분 뒤 도착 예정입니다(%s 정거장 전) — "
+                                              "실시간 정보라 변동될 수 있습니다"
+                                           % (nlf.get("route_name") or rid, nlf["predict_min"],
+                                              nlf.get("stops_away") if nlf.get("stops_away") is not None else "?"))
+                elif live.get("items"):
+                    leg["warnings"] = [w for w in leg["warnings"] if w != LOW_BUS_WARNING]
+                    leg["warnings"].insert(0, "지금 오는 차량은 저상버스가 아닙니다 — "
+                                              "다음 저상 차량은 도착정보에서 다시 확인하세요")
+        elif leg["kind"] == "subway":
+            for key in ("board", "alight"):
+                st = leg[key]
+                st["facilities"] = _station_brief(st["poi_id"], st["name"])
+
+
 def _plan_multimodal(origin_lat, origin_lng, dest: Destination, profile_id: str,
-                     mode: str, constraints=None) -> dict:
+                     mode: str, constraints=None, realtime: bool = False) -> dict:
     if not NET.loaded:
         raise HTTPException(status_code=503, detail="네트워크가 로드되지 않았습니다")
     profile = _profile_or_400(profile_id)
@@ -469,6 +542,8 @@ def _plan_multimodal(origin_lat, origin_lng, dest: Destination, profile_id: str,
             status_code=422,
             detail="대중교통 접근 도보 경로를 만들 수 없습니다 (%s)" % last_err,
         )
+
+    _attach_realtime(legs, realtime)
 
     # ── 통합 요약·geometry·steps ──
     walk_legs = [l for l in legs if l["kind"] == "walk"]
@@ -554,7 +629,7 @@ def route_plan(req: PlanRequest):
     if req.mode in ("walk_bus", "walk_bus_subway"):
         return _plan_multimodal(
             req.origin.lat, req.origin.lng, req.destination,
-            req.profile, req.mode, req.constraints,
+            req.profile, req.mode, req.constraints, realtime=req.realtime,
         )
     if req.mode not in ("", "walk", None):
         raise HTTPException(status_code=400,
@@ -761,6 +836,69 @@ def transit_access_points(
     _profile_or_400(profile)
     items = poi_store.STORE.list_transit_access(lat, lng, radius_m, profile, limit)
     return {"source": poi_store.STORE.source, "count": len(items), "items": items}
+
+
+@app.get("/transit/bus/arrivals", tags=["transit"], dependencies=[Depends(auth)])
+def transit_bus_arrivals(
+    station_id: str = Query(..., description="GBIS 정류소 ID (tran_bus_station_info.station_id)"),
+    route_id: str = Query("", description="지정 시 그 노선만 남긴다(경로 안내 중 승차 노선 확인)"),
+):
+    """정류장 실시간 도착정보 — 노선별 1·2번째 차량의 도착 예정(분)·정거장 수·**저상 여부**.
+
+    `next_low_floor` 가 가장 빨리 오는 저상 차량이다. 없으면 null — "저상버스가 없다"가
+    아니라 "지금 도착정보에 잡힌 두 대 안에는 없다"는 뜻이다(3번째 이후는 위치정보로 본다).
+    실시간 조회에 실패하면 `status: unavailable` 로 답하고 경로 안내 자체는 막지 않는다.
+    """
+    try:
+        meta = poi_store.STORE.stop_route_meta(station_id)
+    except Exception as e:
+        logger.warning("정류장 노선 메타 조회 실패 %s: %s", station_id, e)
+        meta = {}
+    out = gbis_live.LIVE.arrivals(station_id, route_id=route_id or None, route_meta=meta)
+    out["source"] = "gbis"
+    return out
+
+
+@app.get("/transit/bus/locations", tags=["transit"], dependencies=[Depends(auth)])
+def transit_bus_locations(
+    route_id: str = Query(..., description="GBIS 노선 ID (tran_bus_route_info.route_id)"),
+):
+    """노선 실시간 차량 위치 — 운행 중인 전 차량의 현재 정류장(순번·이름·좌표)과 저상 여부.
+
+    도착정보가 2대까지만 보여 주므로, 그 뒤에 오는 저상 차량을 찾거나 지도에 버스 아이콘을
+    그릴 때 쓴다. 정류장 좌표는 정적 DB 의 경유정류소를 순번으로 조인한다.
+    """
+    try:
+        idx = {s["station_id"]: s for s in poi_store.STORE.route_stops(route_id)}
+    except Exception as e:
+        logger.warning("노선 경유 정류장 조회 실패 %s: %s", route_id, e)
+        idx = {}
+    out = gbis_live.LIVE.locations(route_id, stop_index=idx)
+    out["source"] = "gbis"
+    return out
+
+
+@app.get("/transit/station/facilities", tags=["transit"], dependencies=[Depends(auth)])
+def transit_station_facilities(
+    stn_cd: str = Query("", description="역 코드(poi_station_access_status.stn_cd)"),
+    name: str = Query("", description="역 이름 — '범계역', '범계' 모두 가능"),
+):
+    """역 편의시설 — 승강기·리프트(출입구·상세위치), 화장실(게이트 안/밖·출구), 승강장
+    (안전발판·스크린도어·열차 이격거리). 유무는 3상태(yes/no/unknown)다.
+
+    개수만 있던 `poi_station_access_status` 에 설비 단위 자료(국가철도공단 파일)를 붙였다.
+    "엘리베이터 3대"가 아니라 "1번 출구 옆 엘리베이터로 올라가 승강장 4-3 출입문 앞
+    엘리베이터를 타라"를 말하기 위한 자료다. 실시간 가동 여부는 제공기관 API 가 없어
+    싣지 않는다.
+    """
+    if not stn_cd and not name.strip():
+        raise HTTPException(status_code=400, detail="stn_cd 또는 name 이 필요합니다")
+    fac = poi_store.STORE.station_facilities(stn_cd=stn_cd, name=name)
+    if fac is None:
+        raise HTTPException(status_code=404, detail="역을 찾을 수 없습니다 (poi_backend=%s)"
+                            % poi_store.STORE.source)
+    fac["source"] = poi_store.STORE.source
+    return fac
 
 
 # ────────────────────────── collect (수집 장치화) ──────────────────────────

--- a/route_service/api/schemas.py
+++ b/route_service/api/schemas.py
@@ -46,6 +46,8 @@ class PlanRequest(BaseModel):
     alternatives: int = Field(1, ge=1, le=3)
     # walk(기존, 기본) | walk_bus(직결 버스 허용) | walk_bus_subway(버스+안양 관내 지하철 허용)
     mode: str = Field("walk", description="walk | walk_bus | walk_bus_subway")
+    realtime: bool = Field(
+        False, description="버스 leg 승차 정류장의 실시간 도착정보(저상 여부)를 함께 붙인다")
 
 
 class RerouteRequest(BaseModel):

--- a/route_service/config.py
+++ b/route_service/config.py
@@ -35,6 +35,12 @@ class Settings:
         )
     )
 
+    # 실시간 버스(GBIS, 공공데이터포털 인증키 하나로 도착·위치 API 모두 호출)
+    gbis_api_key: str = os.environ.get("DATA_GO_KR_API_KEY", os.environ.get("GBIS_API_KEY", ""))
+    gbis_base_url: str = os.environ.get("GBIS_BASE_URL", "https://apis.data.go.kr/6410000")
+    gbis_timeout_sec: float = float(os.environ.get("GBIS_TIMEOUT_SEC", "3"))
+    gbis_cache_ttl_sec: float = float(os.environ.get("GBIS_CACHE_TTL_SEC", "20"))
+
     # 탐색 파라미터
     snap_max_dist_m: float = float(os.environ.get("SNAP_MAX_DIST_M", "300"))
     max_alternatives: int = int(os.environ.get("MAX_ALTERNATIVES", "2"))

--- a/route_service/poi/store.py
+++ b/route_service/poi/store.py
@@ -14,11 +14,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import re
 
 from ..engine.geo import haversine_m
+
+logger = logging.getLogger("route_api.poi")
 
 # 01-IITP-DABT-Database `poi_tour_bf_facility` 실제 컬럼 (2026-07-13 실측)
 TOUR_FIELDS = [
@@ -55,6 +58,18 @@ DISABILITY_REQUIREMENTS = {
     "청각장애": ["audio_guide_yn"],
     "영유아동반": ["nursing_room_yn", "stroller_rent_yn"],
 }
+
+
+def _yn3(v) -> str:
+    """Y/N/NULL 을 yes/no/unknown 으로. NULL 은 "없음"이 아니라 "자료 없음"이다."""
+    if v is None:
+        return "unknown"
+    t = str(v).strip().upper()
+    if t in ("Y", "YES", "TRUE", "1"):
+        return "yes"
+    if t in ("N", "NO", "FALSE", "0"):
+        return "no"
+    return "unknown"
 
 
 def _is_y(v) -> bool:
@@ -534,10 +549,17 @@ class PoiStore:
         else:
             rows = self._query(
                 """
-                SELECT stn_cd AS poi_id, stn_name AS name, latitude, longitude,
-                       elevator_cnt, wheelchair_lift_cnt, dis_toilet_yn, dis_slope_yn
-                  FROM poi_station_access_status
-                 WHERE del_yn = 'N' AND anyang_yn = 'Y'
+                SELECT s.stn_cd AS poi_id, s.stn_name AS name, s.line_name, s.latitude, s.longitude,
+                       s.elevator_cnt, s.wheelchair_lift_cnt, s.dis_slope_yn,
+                       -- 코레일 API 가 응답하지 않는 역(NULL)은 설비 단위 화장실 자료로 보완한다
+                       COALESCE(s.dis_toilet_yn,
+                                CASE WHEN EXISTS (SELECT 1 FROM poi_station_toilet_unit t
+                                                   WHERE t.stn_name = s.stn_name AND t.disabled_yn = 'Y'
+                                                     AND COALESCE(t.del_yn, 'N') = 'N'
+                                                     AND (s.line_name IS NULL OR t.line_name = s.line_name))
+                                     THEN 'Y' END) AS dis_toilet_yn
+                  FROM poi_station_access_status s
+                 WHERE s.del_yn = 'N' AND s.anyang_yn = 'Y'
                 """,
                 {},
             )
@@ -553,6 +575,10 @@ class PoiStore:
                 "elevator_cnt": int(r.get("elevator_cnt") or 0),
                 "wheelchair_lift_cnt": int(r.get("wheelchair_lift_cnt") or 0),
                 "dis_toilet_yn": _is_y(r.get("dis_toilet_yn")),
+                # NULL(자료 없음)과 N(없음)은 다르다 — 6역은 코레일 API 가 응답하지 않아 NULL 이다
+                "dis_toilet_status": _yn3(r.get("dis_toilet_yn")),
+                "dis_slope_status": _yn3(r.get("dis_slope_yn")),
+                "line": r.get("line_name") or r.get("line"),
             })
         return norm
 
@@ -675,6 +701,186 @@ class PoiStore:
                 "name": r.get("name"),
                 "mobile_no": (str(mob).strip() or None) if mob else None,
                 "lat": float(lat_v), "lng": float(lng_v),
+            })
+        return out
+
+    # ---------- 역 편의시설 (설비 단위, v1.19.0) ----------
+    _FACILITY_UNIT_TABLES = {
+        # 키: (테이블, 정렬 컬럼, 반환 컬럼)
+        "elevators": ("poi_station_elevator_unit", "unit_seq",
+                      "exit_no, detail_loc, capacity_person, capacity_kg"),
+        "lifts": ("poi_station_wheelchair_lift", "mng_no",
+                  "mng_no, exit_no, detail_loc, length_mm, width_mm, start_floor, end_floor"),
+        "toilets": ("poi_station_toilet_unit", "unit_seq",
+                    "gate_inout, exit_no, detail_loc, toilet_kind, disabled_yn, floor_no, ground_dv"),
+        "platforms": ("poi_station_platform", "platform_no",
+                      "platform_no, updown, ground_dv, floor_no, platform_connect_yn, "
+                      "screen_door_yn, safety_plate_yn, gap_min_cm, gap_max_cm, gap_avg_cm, door_cnt"),
+    }
+
+    def station_facilities(self, stn_cd: str = "", name: str = ""):
+        """역 하나의 편의시설 — 개수·유무(poi_station_access_status)에 설비 단위
+        상세(엘리베이터·리프트·화장실·승강장)를 붙인다.
+
+        개수만으로는 "어느 출입구 엘리베이터를 타라"를 말할 수 없다. 설비 단위 자료가
+        DB 에 없으면 목록이 비어 오고, 그때는 개수·유무만으로 안내한다.
+        유무 필드는 3상태(yes/no/unknown)다 — 코레일 API 가 응답하지 않는 역은 NULL 이라
+        "없음"으로 말하면 틀린다.
+        """
+        if self.backend == "none":
+            return None
+        key = _norm_name(name or "")
+        key = key[:-1] if key.endswith("역") and len(key) > 1 else key
+        if self.backend == "file":
+            for r in self._load_file("station_facilities.json"):
+                if (stn_cd and str(r.get("stn_cd")) == str(stn_cd)) or \
+                        (key and _norm_name(r.get("name") or r.get("stn_name") or "") == key):
+                    return self._norm_facilities(r)
+            return None
+        params = {"cd": stn_cd or "", "name": key or ""}
+        rows = self._query(
+            """
+            SELECT stn_cd, stn_name, line_name, latitude, longitude, anyang_yn, base_dt,
+                   elevator_cnt, escalator_cnt, wheelchair_lift_cnt,
+                   dis_slope_yn, dis_toilet_yn, gen_toilet_yn, nursing_room_yn, info_center_yn
+              FROM poi_station_access_status
+             WHERE del_yn = 'N'
+               AND ((:cd <> '' AND stn_cd = :cd) OR (:name <> '' AND stn_name = :name))
+             ORDER BY anyang_yn DESC, stn_cd
+             LIMIT 1
+            """, params)
+        if not rows:
+            return None
+        base = dict(rows[0])
+        line = base.get("line_name")
+        for k, (table, order_col, cols) in self._FACILITY_UNIT_TABLES.items():
+            sql = ("SELECT %s FROM %s WHERE del_yn = 'N' AND stn_name = :name"
+                   % (cols, table))
+            p = {"name": base["stn_name"]}
+            if line:
+                sql += " AND line_name = :line"
+                p["line"] = line
+            sql += " ORDER BY %s" % order_col
+            try:
+                base[k] = self._query(sql, p)
+            except Exception as e:          # 테이블 미생성(적재 전) — 목록만 비운다
+                logger.warning("역 설비 조회 실패 %s: %s", table, e)
+                base[k] = []
+        return self._norm_facilities(base)
+
+    @staticmethod
+    def _norm_facilities(r: dict) -> dict:
+        def _i(v):
+            return None if v is None or v == "" else int(v)
+
+        def _f(v):
+            return None if v is None or v == "" else round(float(v), 1)
+
+        def _s(v):
+            return None if v is None else (str(v).strip() or None)
+
+        elevators = [{"exit_no": _s(e.get("exit_no")), "detail_loc": _s(e.get("detail_loc")),
+                      "capacity_person": _i(e.get("capacity_person")),
+                      "capacity_kg": _i(e.get("capacity_kg"))}
+                     for e in (r.get("elevators") or [])]
+        lifts = [{"mng_no": _s(l.get("mng_no")), "exit_no": _s(l.get("exit_no")),
+                  "detail_loc": _s(l.get("detail_loc")),
+                  "length_mm": _i(l.get("length_mm")), "width_mm": _i(l.get("width_mm")),
+                  "start_floor": _s(l.get("start_floor")), "end_floor": _s(l.get("end_floor"))}
+                 for l in (r.get("lifts") or [])]
+        toilets = [{"gate_inout": _s(t.get("gate_inout")), "exit_no": _s(t.get("exit_no")),
+                    "detail_loc": _s(t.get("detail_loc")), "kind": _s(t.get("toilet_kind") or t.get("kind")),
+                    "disabled": _is_y(t.get("disabled_yn", t.get("disabled"))),
+                    "floor": _s(t.get("floor_no") or t.get("floor")),
+                    "ground": _s(t.get("ground_dv") or t.get("ground"))}
+                   for t in (r.get("toilets") or [])]
+        platforms = [{"platform_no": _s(p.get("platform_no")), "updown": _s(p.get("updown")),
+                      "ground": _s(p.get("ground_dv") or p.get("ground")),
+                      "floor": _s(p.get("floor_no") or p.get("floor")),
+                      "platform_connect": _yn3(p.get("platform_connect_yn")),
+                      "screen_door": _yn3(p.get("screen_door_yn")),
+                      "safety_plate": _yn3(p.get("safety_plate_yn")),
+                      "gap_min_cm": _f(p.get("gap_min_cm")), "gap_max_cm": _f(p.get("gap_max_cm")),
+                      "gap_avg_cm": _f(p.get("gap_avg_cm")), "door_cnt": _i(p.get("door_cnt"))}
+                     for p in (r.get("platforms") or [])]
+        lat = r.get("latitude", r.get("lat"))
+        lng = r.get("longitude", r.get("lng"))
+        ev_cnt = _i(r.get("elevator_cnt"))
+        lift_cnt = _i(r.get("wheelchair_lift_cnt"))
+        return {
+            "poi_id": str(r.get("stn_cd") or r.get("poi_id") or ""),
+            "name": r.get("stn_name") or r.get("name"),
+            "line": r.get("line_name") or r.get("line"),
+            "lat": float(lat) if lat is not None else None,
+            "lng": float(lng) if lng is not None else None,
+            "anyang": _is_y(r.get("anyang_yn", "Y")),
+            "base_dt": str(r.get("base_dt")) if r.get("base_dt") else None,
+            "counts": {
+                "elevator": ev_cnt if ev_cnt is not None else len(elevators) or None,
+                "escalator": _i(r.get("escalator_cnt")),
+                "wheelchair_lift": lift_cnt if lift_cnt is not None else len(lifts) or None,
+            },
+            "status": {
+                "dis_slope": _yn3(r.get("dis_slope_yn")),
+                "dis_toilet": ("yes" if any(t["disabled"] for t in toilets)
+                               else _yn3(r.get("dis_toilet_yn"))),
+                "gen_toilet": ("yes" if any(not t["disabled"] for t in toilets)
+                               else _yn3(r.get("gen_toilet_yn"))),
+                "nursing_room": _yn3(r.get("nursing_room_yn")),
+                "info_center": _yn3(r.get("info_center_yn")),
+                "safety_plate": ("yes" if any(p["safety_plate"] == "yes" for p in platforms)
+                                 else ("no" if platforms and all(p["safety_plate"] == "no" for p in platforms)
+                                       else "unknown")),
+            },
+            "elevators": elevators,
+            "lifts": lifts,
+            "toilets": toilets,
+            "platforms": platforms,
+        }
+
+    def stop_route_meta(self, station_id) -> dict:
+        """정류장을 지나는 노선의 정적 메타 {route_id: {name,type,end_station}} —
+        실시간 도착정보에 노선 유형·종점명을 덧입히는 데 쓴다."""
+        out = {}
+        for s in self._stops(poi_id=str(station_id)):
+            for r in s.get("routes") or []:
+                if isinstance(r, dict) and r.get("route_id") is not None:
+                    out[str(r["route_id"])] = {"name": r.get("name"), "type": r.get("type"),
+                                               "end_station": r.get("end_station")}
+        return out
+
+    def route_stops(self, route_id) -> list:
+        """노선의 전 경유 정류장(순번 오름차순, station_id 포함) — 차량 위치를 정류장에 붙인다."""
+        if self.backend == "none":
+            return []
+        if self.backend == "file":
+            rows = [r for r in self._load_file("transit_route_paths.json")
+                    if str(r.get("route_id")) == str(route_id)]
+            rows.sort(key=lambda r: int(r.get("station_seq", 0)))
+        else:
+            rows = self._query(
+                """
+                SELECT rs.station_seq, rs.station_id, s.station_name AS name, s.mobile_no,
+                       s.latitude, s.longitude
+                  FROM tran_bus_route_station rs
+                  JOIN tran_bus_station_info s ON s.station_id = rs.station_id
+                 WHERE rs.route_id = :route_id
+                   AND COALESCE(rs.del_yn, 'N') = 'N'
+                   AND COALESCE(s.del_yn, 'N') = 'N'
+                 ORDER BY rs.station_seq
+                """, {"route_id": route_id})
+        out = []
+        for r in rows:
+            lat_v = r.get("lat", r.get("latitude"))
+            lng_v = r.get("lng", r.get("longitude"))
+            mob = r.get("mobile_no")
+            out.append({
+                "station_id": str(r.get("station_id") or r.get("poi_id") or ""),
+                "station_seq": int(r.get("station_seq") or 0),
+                "name": r.get("name"),
+                "mobile_no": (str(mob).strip() or None) if mob else None,
+                "lat": float(lat_v) if lat_v is not None else None,
+                "lng": float(lng_v) if lng_v is not None else None,
             })
         return out
 

--- a/route_service/transit/gbis_live.py
+++ b/route_service/transit/gbis_live.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+"""경기버스정보(GBIS) 실시간 조회 — 정류장 도착정보 · 노선 차량 위치.
+
+정적 데이터(01 `tran_bus_*`)에는 저상버스 정차 여부가 없다. 그래서 지금까지는
+"실시간 도착정보로 확인하세요"라는 경고만 붙여 왔고, 확인은 이용자 몫이었다.
+이 모듈이 그 확인을 서비스 안으로 가져온다.
+
+- 도착정보 `getBusArrivalListv2?stationId=`  — 정류장 기준, 노선별 1·2번째 차량의
+  도착 예정(분)·몇 정거장 전·**저상 여부(lowPlate)**·차량번호
+- 위치정보 `getBusLocationListv2?routeId=`   — 노선 기준, 운행 중인 전 차량의
+  현재 정류장 순번·저상 여부
+
+인증키는 공공데이터포털 일반 인증키(`DATA_GO_KR_API_KEY`) 하나로 두 API 를 모두 부른다.
+호출 실패는 예외로 올리지 않고 ``{"status": "unavailable", "reason": ...}`` 로 돌려준다 —
+실시간을 못 붙였다고 경로 안내가 멈추면 안 된다.
+
+응답 값의 빈 항목은 빈 문자열("")로 온다(실측 2026-09-02). 정수 변환은 전부 관대하게 한다.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger("route_api.gbis")
+
+ARRIVAL_PATH = "/busarrivalservice/v2/getBusArrivalListv2"
+LOCATION_PATH = "/buslocationservice/v2/getBusLocationListv2"
+
+# lowPlate: 0 일반 / 1 저상 / 2 2층 등 특수차량 — 휠체어 승차 기준으로는 1 만 '저상'이다
+LOW_FLOOR_CODE = 1
+
+# stateCd(위치정보): 0 교차로 통과 / 1 정류소 도착 / 2 정류소 출발
+STATE_LABEL = {0: "이동 중", 1: "정류소 도착", 2: "정류소 출발"}
+
+
+def _int(v, default=None):
+    if v is None or v == "":
+        return default
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        try:
+            return int(float(v))
+        except (TypeError, ValueError):
+            return default
+
+
+def _str(v):
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+class GbisLive:
+    """실시간 조회 클라이언트. 같은 정류장·노선을 짧은 간격으로 반복 조회하는 폴링을
+    TTL 캐시로 흡수한다(개발계정 도착정보 한도 1,000회/일)."""
+
+    def __init__(self, api_key: str = "", base_url: str = "https://apis.data.go.kr/6410000",
+                 timeout_sec: float = 3.0, cache_ttl_sec: float = 20.0, fetch=None):
+        self.api_key = api_key or ""
+        self.base_url = (base_url or "").rstrip("/")
+        self.timeout_sec = float(timeout_sec)
+        self.cache_ttl_sec = float(cache_ttl_sec)
+        self._fetch = fetch or self._http_get
+        self._cache = {}
+        self._lock = threading.Lock()
+
+    # ---------- 공통 ----------
+    @property
+    def enabled(self) -> bool:
+        return bool(self.api_key)
+
+    def _http_get(self, url: str) -> dict:
+        req = urllib.request.Request(url, headers={"User-Agent": "iitp-dabt-route/1.0"})
+        with urllib.request.urlopen(req, timeout=self.timeout_sec) as r:
+            return json.loads(r.read().decode("utf-8"))
+
+    def _url(self, path: str, **params) -> str:
+        q = {"serviceKey": self.api_key, "format": "json"}
+        q.update({k: v for k, v in params.items() if v not in (None, "")})
+        return "%s%s?%s" % (self.base_url, path, urllib.parse.urlencode(q))
+
+    def _get(self, key: tuple, path: str, **params):
+        """캐시 → 호출. 반환: (msg_body dict | None, error str | None)."""
+        now = time.time()
+        with self._lock:
+            hit = self._cache.get(key)
+            if hit and hit[0] > now:
+                return hit[1], hit[2]
+        if not self.enabled:
+            return None, "인증키가 설정되지 않았습니다(DATA_GO_KR_API_KEY)"
+        body, err = None, None
+        try:
+            data = self._fetch(self._url(path, **params))
+            resp = (data or {}).get("response") or {}
+            head = resp.get("msgHeader") or {}
+            code = _int(head.get("resultCode"), -1)
+            if code == 0:
+                body = resp.get("msgBody") or {}
+            elif code == 4:
+                body = {}                    # 결과 없음 — 정상 응답의 한 형태
+            else:
+                err = "GBIS resultCode=%s %s" % (code, head.get("resultMessage") or "")
+        except urllib.error.HTTPError as e:
+            err = "HTTP %s" % e.code
+        except (urllib.error.URLError, TimeoutError, OSError, ValueError) as e:
+            err = "%s: %s" % (type(e).__name__, e)
+        if err:
+            logger.warning("GBIS 호출 실패 %s %s — %s", path, params, err)
+        with self._lock:
+            # 실패도 짧게 캐시한다 — 장애 중 폴링이 외부 API 를 두드리지 않게
+            ttl = self.cache_ttl_sec if not err else min(self.cache_ttl_sec, 10.0)
+            self._cache[key] = (now + ttl, body, err)
+            if len(self._cache) > 500:
+                self._cache.clear()
+        return body, err
+
+    # ---------- 도착정보 ----------
+    @staticmethod
+    def _vehicle(item: dict, n: int):
+        plate = _str(item.get("plateNo%d" % n))
+        pred = _int(item.get("predictTime%d" % n))
+        if plate is None and pred is None:
+            return None
+        low = _int(item.get("lowPlate%d" % n))
+        return {
+            "order": n,
+            "predict_min": pred,
+            "predict_sec": _int(item.get("predictTimeSec%d" % n)),
+            "stops_away": _int(item.get("locationNo%d" % n)),
+            "current_stop": _str(item.get("stationNm%d" % n)),
+            "low_floor": (low == LOW_FLOOR_CODE) if low is not None else None,
+            "plate_no": plate,
+            "remain_seat_cnt": _int(item.get("remainSeatCnt%d" % n)),
+            "crowded": _int(item.get("crowded%d" % n)),
+        }
+
+    def arrivals(self, station_id, route_id=None, route_meta: dict = None) -> dict:
+        """정류장 도착정보.
+
+        route_meta: {route_id(str): {"name","type","end_station"}} — 정적 DB 의 노선명·유형을
+        덧입힌다(도착 API 도 routeName 을 주지만 유형은 코드뿐이다).
+        route_id 를 주면 그 노선만 남긴다(경로 안내 중 승차 노선 확인용).
+        """
+        body, err = self._get(("arr", str(station_id)), ARRIVAL_PATH, stationId=station_id)
+        if err:
+            return {"status": "unavailable", "reason": err, "station_id": str(station_id),
+                    "items": [], "next_low_floor": None}
+        raw = (body or {}).get("busArrivalList") or []
+        if isinstance(raw, dict):
+            raw = [raw]
+        items = []
+        for it in raw:
+            rid = _str(it.get("routeId"))
+            if route_id is not None and str(route_id) != rid:
+                continue
+            meta = (route_meta or {}).get(rid) or {}
+            vehicles = [v for v in (self._vehicle(it, 1), self._vehicle(it, 2)) if v]
+            items.append({
+                "route_id": rid,
+                "route_name": meta.get("name") or _str(it.get("routeName")),
+                "route_type": meta.get("type"),
+                "end_station": meta.get("end_station") or _str(it.get("routeDestName")),
+                "station_seq": _int(it.get("staOrder")),
+                "flag": _str(it.get("flag")),
+                "vehicles": vehicles,
+            })
+        items.sort(key=lambda x: (x["vehicles"][0]["predict_min"] if x["vehicles"]
+                                  and x["vehicles"][0]["predict_min"] is not None else 9999,
+                                  x["route_name"] or ""))
+        return {
+            "status": "success",
+            "station_id": str(station_id),
+            "queried_at": int(time.time()),
+            "items": items,
+            "next_low_floor": self.next_low_floor(items),
+        }
+
+    @staticmethod
+    def next_low_floor(items: list):
+        """가장 빨리 오는 저상 차량 하나. 없으면 None."""
+        best = None
+        for it in items:
+            for v in it.get("vehicles") or []:
+                if not v.get("low_floor"):
+                    continue
+                pm = v.get("predict_min")
+                if pm is None:
+                    continue
+                cand = {"route_id": it["route_id"], "route_name": it.get("route_name"),
+                        "route_type": it.get("route_type"), "end_station": it.get("end_station"),
+                        "predict_min": pm, "stops_away": v.get("stops_away"),
+                        "plate_no": v.get("plate_no")}
+                if best is None or pm < best["predict_min"]:
+                    best = cand
+        return best
+
+    # ---------- 위치정보 ----------
+    def locations(self, route_id, stop_index: dict = None) -> dict:
+        """노선의 운행 차량 위치. stop_index: {station_id(str): {"name","lat","lng","station_seq"}}
+        가 있으면 차량이 있는 정류장의 이름·좌표를 붙인다(지도 표시용)."""
+        body, err = self._get(("loc", str(route_id)), LOCATION_PATH, routeId=route_id)
+        if err:
+            return {"status": "unavailable", "reason": err, "route_id": str(route_id),
+                    "vehicles": [], "low_floor_cnt": 0}
+        raw = (body or {}).get("busLocationList") or []
+        if isinstance(raw, dict):
+            raw = [raw]
+        vehicles = []
+        for it in raw:
+            sid = _str(it.get("stationId"))
+            low = _int(it.get("lowPlate"))
+            st = _int(it.get("stateCd"))
+            v = {
+                "vehicle_id": _str(it.get("vehId")),
+                "plate_no": _str(it.get("plateNo")),
+                "low_floor": (low == LOW_FLOOR_CODE) if low is not None else None,
+                "station_id": sid,
+                "station_seq": _int(it.get("stationSeq")),
+                "state": STATE_LABEL.get(st, None),
+                "remain_seat_cnt": _int(it.get("remainSeatCnt")),
+                "crowded": _int(it.get("crowded")),
+            }
+            info = (stop_index or {}).get(sid)
+            if info:
+                v["station_name"] = info.get("name")
+                v["lat"] = info.get("lat")
+                v["lng"] = info.get("lng")
+            vehicles.append(v)
+        vehicles.sort(key=lambda x: (x["station_seq"] if x["station_seq"] is not None else 9999))
+        return {
+            "status": "success",
+            "route_id": str(route_id),
+            "queried_at": int(time.time()),
+            "vehicles": vehicles,
+            "low_floor_cnt": sum(1 for v in vehicles if v["low_floor"]),
+        }
+
+
+def configure(settings) -> GbisLive:
+    return GbisLive(api_key=settings.gbis_api_key, base_url=settings.gbis_base_url,
+                    timeout_sec=settings.gbis_timeout_sec,
+                    cache_ttl_sec=settings.gbis_cache_ttl_sec)
+
+
+LIVE = GbisLive()

--- a/tests/test_bus_realtime.py
+++ b/tests/test_bus_realtime.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+"""실시간 버스(GBIS)·역 편의시설 (v1.19.0).
+
+  1) GBIS 응답 정규화 — 빈 문자열("") 항목·저상 판정·가장 빠른 저상 차량
+  2) 실패는 예외가 아니라 status=unavailable 로 (경로 안내는 계속)
+  3) API 계약 — /transit/bus/arrivals·/transit/bus/locations·/transit/station/facilities
+  4) /route/plan realtime=true 는 버스 leg 에 realtime 을 붙이고 고정 경고를 실측 문구로 바꾼다
+  5) 지하철 leg 승·하차 역에 설비 요약(승강기 출입구·장애인화장실 3상태)이 붙는다
+"""
+import json
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from conftest import make_graph  # noqa: E402
+
+from route_service.transit import gbis_live  # noqa: E402
+
+
+# 2026-09-02 실측 응답 축약 — 빈 항목은 "" 로 온다
+ARRIVAL_BODY = {"response": {"msgHeader": {"resultCode": 0, "resultMessage": "정상"},
+                "msgBody": {"busArrivalList": [
+                    {"flag": "PASS", "locationNo1": 10, "locationNo2": "", "lowPlate1": 0,
+                     "lowPlate2": "", "plateNo1": "경기71바1468", "plateNo2": "",
+                     "predictTime1": 11, "predictTime2": "", "predictTimeSec1": 660,
+                     "routeDestName": "구로디지털단지역(중)", "routeId": 208000007,
+                     "routeName": 1, "staOrder": 23, "stationId": 208000069,
+                     "stationNm1": "안양우편물류센터", "stationNm2": ""},
+                    {"flag": "PASS", "locationNo1": 6, "locationNo2": 14, "lowPlate1": 1,
+                     "lowPlate2": 1, "plateNo1": "경기71바1118", "plateNo2": "경기71바1119",
+                     "predictTime1": 9, "predictTime2": 17, "routeDestName": "충훈부종점",
+                     "routeId": 208000096, "routeName": 51, "staOrder": 30,
+                     "stationId": 208000069, "stationNm1": "남부시장", "stationNm2": "박달"},
+                ]}}}
+
+LOCATION_BODY = {"response": {"msgHeader": {"resultCode": 0},
+                 "msgBody": {"busLocationList": [
+                     {"crowded": 0, "lowPlate": 0, "plateNo": "경기71바8004", "remainSeatCnt": -1,
+                      "routeId": 241253001, "stateCd": 0, "stationId": 208000305,
+                      "stationSeq": 3, "vehId": 289000652},
+                     {"crowded": 0, "lowPlate": 1, "plateNo": "경기71바9299", "remainSeatCnt": -1,
+                      "routeId": 241253001, "stateCd": 1, "stationId": 208000069,
+                      "stationSeq": 10, "vehId": 289000656},
+                 ]}}}
+
+EMPTY_BODY = {"response": {"msgHeader": {"resultCode": 4, "resultMessage": "결과가 존재하지 않습니다"},
+                           "msgBody": None}}
+
+
+def _live(responses):
+    calls = []
+
+    def fetch(url):
+        calls.append(url)
+        for key, body in responses.items():
+            if key in url:
+                if isinstance(body, Exception):
+                    raise body
+                return body
+        raise AssertionError("예상치 못한 URL: %s" % url)
+    live = gbis_live.GbisLive(api_key="k", fetch=fetch, cache_ttl_sec=60)
+    live.calls = calls
+    return live
+
+
+# ── 1. 정규화 ────────────────────────────────────────────────
+def test_arrivals_normalizes_blank_fields_and_low_floor():
+    live = _live({"getBusArrivalListv2": ARRIVAL_BODY})
+    out = live.arrivals(208000069, route_meta={"208000096": {"name": "51", "type": "일반형시내버스",
+                                                             "end_station": "충훈부"}})
+    assert out["status"] == "success"
+    by_route = {it["route_id"]: it for it in out["items"]}
+    r1 = by_route["208000007"]
+    assert len(r1["vehicles"]) == 1, "2번째 차량 항목이 전부 빈 문자열이면 차량이 없는 것"
+    assert r1["vehicles"][0]["low_floor"] is False
+    assert r1["route_name"] == "1" and r1["end_station"] == "구로디지털단지역(중)"
+    r51 = by_route["208000096"]
+    assert r51["route_type"] == "일반형시내버스" and r51["end_station"] == "충훈부"
+    assert [v["low_floor"] for v in r51["vehicles"]] == [True, True]
+    assert [v["predict_min"] for v in r51["vehicles"]] == [9, 17]
+    # 가장 빨리 오는 저상 차량
+    assert out["next_low_floor"]["route_name"] == "51"
+    assert out["next_low_floor"]["predict_min"] == 9
+    assert out["next_low_floor"]["stops_away"] == 6
+
+
+def test_arrivals_route_filter_and_no_low_floor():
+    live = _live({"getBusArrivalListv2": ARRIVAL_BODY})
+    out = live.arrivals(208000069, route_id="208000007")
+    assert [it["route_id"] for it in out["items"]] == ["208000007"]
+    assert out["next_low_floor"] is None, "일반 차량뿐이면 저상 없음(None)"
+
+
+def test_arrivals_empty_result_code_4_is_success_with_no_items():
+    live = _live({"getBusArrivalListv2": EMPTY_BODY})
+    out = live.arrivals(1)
+    assert out["status"] == "success" and out["items"] == [] and out["next_low_floor"] is None
+
+
+def test_locations_normalizes_and_joins_stop_index():
+    live = _live({"getBusLocationListv2": LOCATION_BODY})
+    idx = {"208000069": {"name": "안양역", "lat": 37.4019, "lng": 126.9226, "station_seq": 10}}
+    out = live.locations(241253001, stop_index=idx)
+    assert out["status"] == "success" and out["low_floor_cnt"] == 1
+    v = [x for x in out["vehicles"] if x["station_id"] == "208000069"][0]
+    assert v["low_floor"] is True and v["state"] == "정류소 도착"
+    assert v["station_name"] == "안양역" and v["lat"] == 37.4019
+
+
+# ── 2. 실패 처리 ──────────────────────────────────────────────
+def test_fetch_failure_returns_unavailable_not_exception():
+    live = _live({"getBusArrivalListv2": OSError("connection refused")})
+    out = live.arrivals(208000069)
+    assert out["status"] == "unavailable" and "OSError" in out["reason"]
+    assert out["items"] == [] and out["next_low_floor"] is None
+
+
+def test_no_api_key_is_unavailable_without_calling():
+    live = gbis_live.GbisLive(api_key="", fetch=lambda u: (_ for _ in ()).throw(AssertionError("호출 금지")))
+    out = live.arrivals(1)
+    assert out["status"] == "unavailable" and "인증키" in out["reason"]
+
+
+def test_cache_absorbs_repeated_polling():
+    live = _live({"getBusArrivalListv2": ARRIVAL_BODY})
+    live.arrivals(208000069)
+    live.arrivals(208000069)
+    live.arrivals(208000069, route_id="208000007")   # 필터만 달라도 같은 정류장 캐시
+    assert len(live.calls) == 1
+
+
+# ── 3~5. API 계약 ─────────────────────────────────────────────
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    import pickle
+
+    net = tmp_path / "network.gpickle"
+    with open(net, "wb") as f:
+        pickle.dump(make_graph(), f)
+    poi_dir = tmp_path / "poi"
+    poi_dir.mkdir()
+    (poi_dir / "tour_bf.json").write_text(json.dumps([{
+        "poi_id": "TBF-1", "name": "테스트 무장애 공원",
+        "addr": "경기도 안양시 만안구 테스트로 1",
+        "latitude": 37.3909, "longitude": 126.9511,
+        "entrance": {"lat": 37.3909, "lng": 126.9511},
+    }], ensure_ascii=False), encoding="utf-8")
+    (poi_dir / "stations.json").write_text(json.dumps([
+        {"poi_id": "ST-A", "name": "안양", "latitude": 37.3901, "longitude": 126.9502,
+         "elevator_cnt": 4, "wheelchair_lift_cnt": 0, "dis_toilet_yn": "Y", "line": "1호선"},
+        {"poi_id": "ST-M", "name": "명학", "latitude": 37.3908, "longitude": 126.9510,
+         "elevator_cnt": 4, "wheelchair_lift_cnt": 0, "line": "1호선"},   # 유무 자료 없음(NULL)
+    ], ensure_ascii=False), encoding="utf-8")
+    (poi_dir / "station_facilities.json").write_text(json.dumps([
+        {"stn_cd": "ST-A", "name": "안양", "line": "1호선", "latitude": 37.3901, "longitude": 126.9502,
+         "elevator_cnt": 4, "escalator_cnt": 6, "wheelchair_lift_cnt": 0,
+         "dis_slope_yn": "Y", "dis_toilet_yn": "Y", "gen_toilet_yn": "Y",
+         "elevators": [{"exit_no": "2", "detail_loc": "(2F) 1번출구 맞이방 서쪽", "capacity_person": 11},
+                       {"exit_no": "내부", "detail_loc": "(1F) 관악역 방향 승강장 4-3 출입문앞"}],
+         "toilets": [{"gate_inout": "외", "exit_no": "2", "detail_loc": "(2층) 대합실내 북쪽 게이트 좌측",
+                      "toilet_kind": "여자", "disabled_yn": "Y"}],
+         "platforms": [{"platform_no": "1", "updown": "상행", "safety_plate_yn": "Y",
+                        "screen_door_yn": "N", "gap_min_cm": 9.5, "gap_max_cm": 11.0}]},
+        {"stn_cd": "ST-M", "name": "명학", "line": "1호선", "latitude": 37.3908, "longitude": 126.9510,
+         "elevator_cnt": 4, "wheelchair_lift_cnt": 0,
+         "elevators": [{"exit_no": "1", "detail_loc": "(1F) 1번 출입구 앞"}]},
+    ], ensure_ascii=False), encoding="utf-8")
+    (poi_dir / "transit_stops.json").write_text(json.dumps([
+        {"poi_id": "208000069", "name": "출발정류장", "lat": 37.3900, "lng": 126.9502,
+         "mobile_no": "09213",
+         "routes": [{"route_id": "208000096", "name": "51", "type": "일반형시내버스",
+                     "end_station": "충훈부", "station_seq": [5]}]},
+        {"poi_id": "BS-D", "name": "도착정류장", "lat": 37.3900, "lng": 126.9512,
+         "mobile_no": "09002",
+         "routes": [{"route_id": "208000096", "name": "51", "type": "일반형시내버스",
+                     "end_station": "충훈부", "station_seq": [9]}]},
+    ], ensure_ascii=False), encoding="utf-8")
+    (poi_dir / "transit_route_paths.json").write_text(json.dumps([
+        {"route_id": "208000096", "station_id": "208000069", "station_seq": 5, "name": "출발정류장",
+         "mobile_no": "09213", "lat": 37.3900, "lng": 126.9502},
+        {"route_id": "208000096", "station_id": "BS-1", "station_seq": 6, "name": "경유1",
+         "mobile_no": "09011", "lat": 37.3899, "lng": 126.9505},
+        {"route_id": "208000096", "station_id": "BS-D", "station_seq": 9, "name": "도착정류장",
+         "mobile_no": "09002", "lat": 37.3900, "lng": 126.9512},
+    ], ensure_ascii=False), encoding="utf-8")
+
+    monkeypatch.setenv("NETWORK_PATH", str(net))
+    monkeypatch.setenv("NETWORK_VERSION", "test-1")
+    monkeypatch.setenv("POI_BACKEND", "file")
+    monkeypatch.setenv("POI_DATA_DIR", str(poi_dir))
+    monkeypatch.setenv("ROUTE_API_TOKEN", "")
+    monkeypatch.setenv("DATA_GO_KR_API_KEY", "test-key")
+
+    import importlib
+    import route_service.config as cfg
+    importlib.reload(cfg)
+    cfg._settings = None
+    import route_service.api.main as m
+    importlib.reload(m)
+    with TestClient(m.app) as c:
+        # 외부 호출을 실측 응답으로 대체
+        live = _live({"getBusArrivalListv2": ARRIVAL_BODY, "getBusLocationListv2": LOCATION_BODY})
+        m.gbis_live.LIVE = live
+        c.live = live
+        yield c
+
+
+def test_health_reports_realtime_flag(client):
+    assert client.get("/health").json()["bus_realtime"] is True
+
+
+def test_bus_arrivals_endpoint_joins_static_route_meta(client):
+    r = client.get("/transit/bus/arrivals", params={"station_id": "208000069"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success" and body["source"] == "gbis"
+    r51 = [it for it in body["items"] if it["route_id"] == "208000096"][0]
+    assert r51["route_type"] == "일반형시내버스", "정적 DB 의 노선 유형이 덧입혀져야 한다"
+    assert body["next_low_floor"]["route_name"] == "51"
+
+
+def test_bus_locations_endpoint_joins_stop_coords(client):
+    r = client.get("/transit/bus/locations", params={"route_id": "208000096"})
+    assert r.status_code == 200
+    v = [x for x in r.json()["vehicles"] if x["station_id"] == "208000069"][0]
+    assert v["station_name"] == "출발정류장" and v["lat"] == 37.39
+
+
+def test_station_facilities_by_name_and_three_state(client):
+    r = client.get("/transit/station/facilities", params={"name": "안양역"})
+    assert r.status_code == 200
+    fac = r.json()
+    assert fac["poi_id"] == "ST-A" and fac["counts"]["elevator"] == 4
+    assert fac["elevators"][0]["exit_no"] == "2"
+    assert fac["toilets"][0]["disabled"] is True
+    assert fac["status"]["dis_toilet"] == "yes" and fac["status"]["safety_plate"] == "yes"
+    assert fac["platforms"][0]["gap_min_cm"] == 9.5
+
+    r = client.get("/transit/station/facilities", params={"stn_cd": "ST-M"})
+    fac = r.json()
+    # 코레일 API 미응답 역 — 유무는 unknown 이지 no 가 아니다
+    assert fac["status"]["dis_toilet"] == "unknown" and fac["status"]["dis_slope"] == "unknown"
+    assert fac["status"]["safety_plate"] == "unknown"
+
+    assert client.get("/transit/station/facilities", params={"name": "없는역"}).status_code == 404
+    assert client.get("/transit/station/facilities").status_code == 400
+
+
+def test_access_points_carry_three_state_toilet(client):
+    r = client.get("/transit/access-points", params={"lat": 37.3901, "lng": 126.9502, "radius_m": 300})
+    st = {it["poi_id"]: it for it in r.json()["items"] if it["type"] == "transit_station"}
+    assert st["ST-A"]["dis_toilet_status"] == "yes"
+    assert st["ST-M"]["dis_toilet_status"] == "unknown"
+
+
+def test_plan_realtime_attaches_arrivals_and_replaces_fixed_warning(client):
+    body = {"origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "tour", "poi_id": "TBF-1"},
+            "profile": "wheelchair_manual", "mode": "walk_bus", "realtime": True}
+    r = client.post("/route/plan", json=body)
+    assert r.status_code == 200, r.text
+    legs = r.json()["routes"][0]["legs"]
+    bus = [l for l in legs if l["kind"] == "bus"][0]
+    assert bus["realtime"]["status"] == "success"
+    assert bus["realtime"]["next_low_floor"]["predict_min"] == 9
+    assert all("보장되지 않습니다" not in w for w in bus["warnings"])
+    assert any("저상버스 51번이 약 9분" in w for w in bus["warnings"])
+    # 스텝에도 승차 정류장·노선 참조가 실린다(프런트 폴링용)
+    steps = r.json()["routes"][0]["steps"]
+    board = [s for s in steps if s["maneuver"] == "bus_board"][0]
+    assert board["leg_ref"] == {"kind": "bus", "route_id": "208000096", "route_name": "51",
+                                "board_station_id": "208000069", "board_name": "출발정류장",
+                                "alight_station_id": "BS-D"}
+
+
+def test_plan_without_realtime_keeps_fixed_warning(client):
+    body = {"origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "tour", "poi_id": "TBF-1"},
+            "profile": "wheelchair_manual", "mode": "walk_bus"}
+    r = client.post("/route/plan", json=body)
+    bus = [l for l in r.json()["routes"][0]["legs"] if l["kind"] == "bus"][0]
+    assert "realtime" not in bus
+    assert any("보장되지 않습니다" in w for w in bus["warnings"])
+    assert client.live.calls == [], "realtime 미요청이면 외부 호출이 없어야 한다"
+
+
+def test_plan_realtime_failure_keeps_fixed_warning(client):
+    client.live._fetch = lambda url: (_ for _ in ()).throw(OSError("down"))
+    client.live._cache.clear()
+    body = {"origin": {"lat": 37.3900, "lng": 126.9500},
+            "destination": {"type": "tour", "poi_id": "TBF-1"},
+            "profile": "wheelchair_manual", "mode": "walk_bus", "realtime": True}
+    r = client.post("/route/plan", json=body)
+    assert r.status_code == 200
+    bus = [l for l in r.json()["routes"][0]["legs"] if l["kind"] == "bus"][0]
+    assert bus["realtime"]["status"] == "unavailable"
+    assert any("보장되지 않습니다" in w for w in bus["warnings"])
+
+
+def test_subway_leg_carries_station_facilities(client):
+    body = {"origin": {"lat": 37.3901, "lng": 126.9501},
+            "destination": {"type": "tour", "poi_id": "TBF-1"},
+            "profile": "wheelchair_manual", "mode": "walk_bus_subway"}
+    r = client.post("/route/plan", json=body)
+    assert r.status_code == 200, r.text
+    subs = [l for l in r.json()["routes"][0]["legs"] if l["kind"] == "subway"]
+    assert subs, "지하철 leg 없음"
+    b = subs[0]["board"]["facilities"]
+    assert b["elevators"] and b["dis_toilet"] in ("yes", "no", "unknown")


### PR DESCRIPTION
## 변경 내용
- `transit/gbis_live.py` (신규) — GBIS 도착정보·위치정보 클라이언트. 빈 문자열 항목 정규화, 저상 판정(`lowPlate==1`), `next_low_floor`, TTL 캐시, 실패는 `status: unavailable`
- `api/main.py` — `GET /transit/bus/arrivals` · `GET /transit/bus/locations` · `GET /transit/station/facilities`; `/route/plan` `realtime` 옵션(버스 leg 도착정보 첨부·고정 경고 교체), 지하철 leg 승·하차 역 설비 요약, 스텝 `leg_ref`; `/health` 에 `bus_realtime`
- `poi/store.py` — `station_facilities` (설비 단위 4표 조인, 3상태), `stop_route_meta`, `route_stops`, 역 항목 `dis_toilet_status`/`dis_slope_status`
- `config.py` / `schemas.py` / `.env.example` — `DATA_GO_KR_API_KEY` 등 설정, `PlanRequest.realtime`
- `tests/test_bus_realtime.py` — 16건 (정규화·실패·캐시·엔드포인트·realtime plan·지하철 설비)
- README — API 표·실시간 버스·역 편의시설 절

## 테스트 방법
- `pytest` 128 passed (기존 112 + 16)
- 검증 서버 배포 후 `/transit/bus/arrivals?station_id=208000069` 실호출로 저상 차량 확인

Closes #56