### PR TITLE
v1.21.1 - 안내 전용 스텝에 링크 병합이 시도되던 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.21.0 |
+| 02-IITP-DABT-Route | v1.21.1 |
 
 ## 구조
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.21.0"
+__version__ = "1.21.1"

--- a/route_service/engine/steps.py
+++ b/route_service/engine/steps.py
@@ -260,6 +260,11 @@ def build_steps(G, path, profile: Profile, merge_m: float = 15.0) -> list:
             steps
             and maneuver == "straight"
             and not special
+            # 노드 부착 횡단보도 스텝(_cw_point)은 링크가 아니라 안내 전용이라
+            # _coords·_warnings 를 갖지 않는다. 여기에 병합하면 KeyError 로 죽는다.
+            # 종전에는 _link_type 이 None 이라 아래 종류 비교에서 자연히 걸러졌는데,
+            # v1.21.0 의 짧은 연결부 흡수 조건이 그 비교를 우회해 버렸다.
+            and not steps[-1].get("_cw_point")
             # 링크 종류가 같거나, 특수 링크 사이에 낀 아주 짧은 연결부이거나 (v1.21.0).
             # 횡단보도 두 개를 연달아 건너는 교차로에서 그 사이 4m 보도가
             # "4m 직진합니다" 라는 독립 지시로 나오던 것을 앞 스텝에 흡수한다.

--- a/tests/test_crosswalk_phrasing.py
+++ b/tests/test_crosswalk_phrasing.py
@@ -83,3 +83,32 @@ def test_real_crossing_link_still_gives_the_order():
     texts = " ".join(x["instruction"] for x in build_steps(s.graph, ["A", "B"],
                                                           get_profile("wheelchair_manual")))
     assert "횡단보도를 건너" in texts
+
+
+def test_short_link_after_crosswalk_step_does_not_crash():
+    """노드 부착 횡단보도 스텝 뒤에 짧은 링크가 오면 병합 대상이 되어선 안 된다.
+
+    회귀: v1.21.0 의 짧은 연결부 흡수 조건이 _link_type 비교를 우회해
+    안내 전용 스텝(_coords 없음)에 병합을 시도하며 KeyError 로 죽었다.
+    """
+    import networkx as nx3
+    G = nx3.Graph()
+    # A -(50m, sidewalk)- B(꺾임 + 횡단보도 부착) -(5m, road)- C -(50m, road)- D
+    G.add_node("A", lat=LAT, lon=LON, node_type="sidewalk", crosswalk_cnt=0)
+    G.add_node("B", lat=LAT, lon=LON + D50, node_type="crossing", crosswalk_cnt=1,
+               cw_curb_cut=None, cw_tactile_paving=None)
+    G.add_node("C", lat=LAT + 5.0 / 110_540.0, lon=LON + D50, node_type="sidewalk",
+               crosswalk_cnt=0)
+    G.add_node("D", lat=LAT + 55.0 / 110_540.0, lon=LON + D50, node_type="sidewalk",
+               crosswalk_cnt=0)
+    G.add_edge("A", "B", length=50.0, slope=0.5, link_type="sidewalk", width=2.0,
+               curb_cut=True, surface="asphalt", link_name="가로", geometry=None)
+    G.add_edge("B", "C", length=5.0, slope=0.5, link_type="road", width=2.0,
+               curb_cut=True, surface="asphalt", link_name="세로", geometry=None)
+    G.add_edge("C", "D", length=50.0, slope=0.5, link_type="road", width=2.0,
+               curb_cut=True, surface="asphalt", link_name="세로", geometry=None)
+    s = NetworkStore()
+    s.load_graph_object(G, version="test-cwcrash", region="테스트")
+    steps = build_steps(s.graph, ["A", "B", "C", "D"], get_profile("wheelchair_manual"))
+    assert steps and steps[-1]["maneuver"] == "arrive"
+    assert all(x["instruction"] for x in steps)


### PR DESCRIPTION
## 변경 내용

노드 부착 횡단보도 스텝은 링크가 아니라 안내 전용이라 좌표열과 경고 목록을 갖지 않는다.
종전에는 링크 종류 비교(`_link_type` 가 `None`)에서 자연히 병합 대상에서 빠졌는데,
v1.21.0 이 추가한 짧은 연결부 흡수 조건이 그 비교를 우회해 병합을 시도했다.
안내 전용 스텝은 병합 대상에서 제외하도록 조건을 보강한다.

## 검증

- 재현 케이스를 회귀 테스트로 추가했다. 가드를 빼면 실패하고 넣으면 통과하는 것을 확인했다.
- pytest 154 -> 155 통과