### PR TITLE
v1.23.0 - 출발·도착 링크 투영 스냅 + 우회 삼각형 직결 링크 정제(하드 게이트·신뢰도·프로필별 활성 하한)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,25 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 - 응답 `origin.snap_kind`·`destination.snap_kind`(`edge`|`node`)·`snap_dist_m`. 끄려면 `EDGE_SNAP=false`(`EDGE_SNAP_RADIUS_M`·`EDGE_SNAP_K`).
 - 실측(anyang-hybrid-2026Q3): 안양아트센터 → 안양문화원 1,283m → **1,060m(우회비 1.55 → 1.28)**, 첫 안내가 목적지 방향. 요청당 약 +40ms.
 
+### 우회 삼각형 직결 링크 정제 — 규칙만으로 (v1.23.0)
+
+A–M, M–B 인접 링크는 있는데 A–B 직결이 없어 짧은 거리를 크게 우회하는 지점(안양문화원 앞 10.6m → 21.8m, 급회전 안내)에
+**사람 검수 없이** 직결 링크를 신설한다. 안전은 하드 게이트가, 선호는 신뢰도(비용)가 맡는다.
+
+```bash
+python scripts/build_topomap_layers.py --src "<1:1000 도엽 폴더>" --out data/topomap_layers          # 인도 면형·장애물 (한 번)
+python scripts/refine_detour_links.py --graph data/network_anyang_hybrid.gpickle --layers data/topomap_layers \
+    --dem data/dem/anyang_5m.tif --report data/refine_report.csv \
+    --out data/network_anyang_hybrid_r1.gpickle --version anyang-hybrid-2026Q3r1
+```
+
+- 후보: 차수 무관, 우회비 ≥ 1.41·우회량 < 20m·직선 ≤ 25m.
+- 하드 게이트(하나라도 걸리면 생성 안 함): 인도 면형 밖(도엽 이음새 0.3m 흡수) · 계단·옹벽·담장·가로시설물 저촉 · 점형 지물 통과 간격 0.8m 미만 · 신설선 종단경사 8° 초과 · 지그재그 경사로(고도차 1m 초과 & 인접 경사 5% 초과) · 우회 구간이 횡단보도 링크.
+- 신뢰도 c(1.0 에서 곱셈 감점): 신설선 내부(양 끝 1m 제외)가 경계 인셋 0.2m 밖 ×0.55 · 보도 폭 1.5m 미만 ×0.70 · A·B 가 **맞닿지 않은** 서로 다른 폴리곤 ×0.60 · 접합각 60° 미만 ×0.70. 인셋 0.2m 는 1:1000 도화 허용오차와 휠체어 반폭 근거.
+- 반영: `topo_source='derived'`·`confidence=c` 로 **추가만** 한다(기존 링크·지그재그 경사로는 그대로). 라우팅은 프로필별 활성 하한(수동 0.60·전동 0.55·시각 0.70·도보 0.40) 미만이면 없는 링크로 보고, 통과분은 `length × (1 + 4(1 − c))` 비용으로 저울질한다.
+- 안양 실측(2026-09-07): 후보 414 → 인도 면형 밖 237(대부분 인도 없는 이면도로) · 횡단보도 우회 173 · **채택 4**(c 1.0·1.0·0.7·0.55). 안양문화원 앞 직결 링크 c=1.0 → 모든 프로필이 10.6m 직결로 지난다. 보고서 `data/refine_report.csv`.
+- 회귀(실증 구간 9건): 거리 불변 또는 단축(안양아트센터 → 안양문화원 1,283 → 1,060m), 계단 관통 링크 증가 0.
+
 ### 저상버스 우선 모드 (v1.22.0)
 
 휠체어 이용자에게 일반버스는 탑승이 불가능하다. 그런데 종전 후보 스코어(도보거리 + 정거장 수 + 탑승 횟수)에는

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.22.0 |
+| 02-IITP-DABT-Route | v1.23.0 |
 
 ## 구조
 
@@ -247,6 +247,18 @@ python scripts/build_network.py --source osm --place "Anyang-si, ..." \
 - 같은 정류장·노선의 반복 폴링은 20초 TTL 캐시로 흡수한다(`GBIS_CACHE_TTL_SEC`). 개발계정 도착정보 한도는 1,000회/일이다.
 - `next_low_floor` 가 `null` 인 것은 "저상버스가 없다"가 아니라 "도착정보에 잡힌 두 대 안에는 없다"는 뜻이다. 3번째 이후 차량은 위치정보로 본다.
 - 스텝(`bus_board`/`bus_alight`)에 `leg_ref{route_id, board_station_id, alight_station_id}` 가 실린다 — 클라이언트가 안내 중 폴링할 키다.
+
+### 링크 투영 스냅 — 출발·도착을 링크 위의 점에 (v1.23.0)
+
+종전에는 출발·도착 좌표를 최근접 **노드**에만 붙였다. 링크 길이 중앙값 47m, 100m 초과 링크가 2,250개인 그래프에서는
+좌표가 긴 링크 중간에 있으면 링크 한쪽 끝까지 갔다가 되돌아오는 경로가 나온다(안양아트센터 → 안양문화원 1,283m / 직선 826m).
+이제 최근접 **링크 위의 점**에 요청 단위 가상 노드를 만들어 붙이고 링크 양쪽으로 나갈 수 있게 한다(`engine/vsnap.py`). 공유 그래프는 바뀌지 않는다.
+
+- 후보: 반경 60m 안 링크에 투영, 가까운 순 3개 + 노드 스냅 폴백. 출발은 도착 최근접 후보를 기준으로, 도착은 고른 출발을 기준으로 **"투영 거리 + 경로 비용"이 최소**인 후보를 택한다(막다른 링크 회피).
+- 안전 필터: 반경 20m 안에 보행 링크(sidewalk 계열)가 있으면 도로 링크 제외 · `crossing`·`steps`·`overpass`·`underpass` 는 투영 금지 · 좌표→투영점 선분이 건물 폴리곤(또는 옹벽·담장 색인)을 가로지르면 탈락(LOS) · 링크 끝 1m 이내면 끝 노드 그대로.
+- 실측 출입구(`manual_survey`·`accessible_entrance`)로 해석된 도착점은 종전대로 노드 스냅 — 출입구 스퍼 끝이 곧 안내 종점이다.
+- 응답 `origin.snap_kind`·`destination.snap_kind`(`edge`|`node`)·`snap_dist_m`. 끄려면 `EDGE_SNAP=false`(`EDGE_SNAP_RADIUS_M`·`EDGE_SNAP_K`).
+- 실측(anyang-hybrid-2026Q3): 안양아트센터 → 안양문화원 1,283m → **1,060m(우회비 1.55 → 1.28)**, 첫 안내가 목적지 방향. 요청당 약 +40ms.
 
 ### 저상버스 우선 모드 (v1.22.0)
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.22.0"
+__version__ = "1.23.0"

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -23,6 +23,7 @@ from ..engine.access import BuildingIndex, ManualEntrances, resolve_access_point
 from ..engine.graph import STORE as NET
 from ..engine.planner import NoRouteError, off_route_distance_m, plan
 from ..engine.snap import SnapError, snap
+from ..engine import vsnap
 from ..engine.steps import build_steps
 from ..collect import store as collect_store
 from ..engine.overrides import apply_overrides
@@ -204,6 +205,75 @@ def _resolve_destination(dest: Destination, profile, allowed=None) -> dict:
     return resolved
 
 
+
+# ────────────────────────── 링크 투영 스냅 (#67, v1.23.0) ──────────────────────────
+ENTRANCE_SOURCES = ("manual_survey", "accessible_entrance")   # 출입구로 해석된 도착점은 노드 스냅 유지
+LOS = None                                                    # 시선 검사(건물·옹벽·담장) — startup 에서 채운다
+
+
+def _los():
+    global LOS
+    if LOS is None:
+        LOS = vsnap.LineOfSight(buildings=BUILDINGS, obstacles=None)
+    return LOS
+
+
+def _endpoint_candidates(H, lat, lng, profile, allowed, tag: str, allow_virtual: bool = True) -> list:
+    """출발·도착 후보 [(node_id, dist_m, (lat,lng), kind)] — 링크 투영 후보(최대 K) 뒤에 노드 스냅 폴백."""
+    out = []
+    if allow_virtual and settings.edge_snap:
+        try:
+            cands = vsnap.candidates(NET, lat, lng, profile, profile.hard_slope() + 4.0, allowed=allowed,
+                                     radius_m=settings.edge_snap_radius_m, k=settings.edge_snap_k, los=_los())
+        except Exception as e:                       # 투영은 개선 기능 — 실패해도 노드 스냅으로 계속
+            logger.warning("링크 투영 스냅 실패(%s) — 노드 스냅으로 진행", e)
+            cands = []
+        for i, c in enumerate(cands):
+            nid = vsnap.attach(H, c, "%s%s_%d" % (vsnap.VIRTUAL_PREFIX, tag, i))
+            out.append((nid, c["dist_m"], (c["lat"], c["lng"]), "edge"))
+    s = snap(NET, lat, lng, profile, settings.snap_max_dist_m, allowed=allowed)
+    out.append((s["node_id"], s["dist_m"], (s["snapped"]["lat"], s["snapped"]["lng"]), "node"))
+    return out
+
+
+def _pair_cost(H, a, b, profile):
+    from ..engine.planner import _astar, edge_cost
+    import networkx as nx
+    for lvl in (profile.hard_slope(), profile.hard_slope() + 4.0):
+        try:
+            path = _astar(H, a, b, profile, lvl)
+        except (nx.NetworkXNoPath, nx.NodeNotFound):
+            continue
+        return sum(edge_cost(H[u][v], profile) for u, v in zip(path[:-1], path[1:]))
+    return None
+
+
+def _choose_endpoints(H, o_cands, d_cands, profile):
+    """(출발 후보, 도착 후보) 중 "투영 거리 + 경로 비용" 최소 조합.
+
+    조합 전수(K+1)² 대신 도착은 최근접 후보로 고정해 출발을 고르고, 그 출발로 도착을 고른다(≤ 2(K+1) 회 탐색).
+    한 쪽이 후보 하나뿐이면 그대로 쓴다. 경로가 없는 후보는 건너뛰고, 전부 없으면 노드 스냅 폴백을 돌려준다.
+    """
+    def pick(fixed, cands, fixed_first):
+        if len(cands) == 1:
+            return cands[0]
+        best = None
+        for c in cands:
+            if c[0] == fixed[0]:
+                continue
+            cost = _pair_cost(H, fixed[0], c[0], profile) if fixed_first else _pair_cost(H, c[0], fixed[0], profile)
+            if cost is None:
+                continue
+            total = cost + c[1]
+            if best is None or total < best[0]:
+                best = (total, c)
+        return best[1] if best else cands[-1]
+
+    o = pick(d_cands[0], o_cands, fixed_first=False)
+    d = pick(o, d_cands, fixed_first=True)
+    return o, d
+
+
 def _plan_core(origin_lat, origin_lng, dest: Destination, profile_id: str,
                alternatives: int, constraints=None) -> dict:
     if not NET.loaded:
@@ -226,26 +296,32 @@ def _plan_core(origin_lat, origin_lng, dest: Destination, profile_id: str,
 
     target = _resolve_destination(dest, profile, allowed)
 
+    # 링크 투영 스냅(#67): 출발지와 좌표·건물 대표점 도착지는 링크 위 점에, 실측 출입구는 노드에 붙인다
+    H = vsnap.virtual_graph(NET)
     try:
-        s = snap(NET, origin_lat, origin_lng, profile, settings.snap_max_dist_m, allowed=allowed)
-        g = snap(NET, target["lat"], target["lng"], profile, settings.snap_max_dist_m, allowed=allowed)
+        o_cands = _endpoint_candidates(H, origin_lat, origin_lng, profile, allowed, "o")
+        d_cands = _endpoint_candidates(H, target["lat"], target["lng"], profile, allowed, "d",
+                                       allow_virtual=target.get("source") not in ENTRANCE_SOURCES)
     except SnapError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
-    if not s["reachable"]:
+    if all(c[1] > settings.snap_max_dist_m for c in o_cands):
         raise HTTPException(
             status_code=422,
             detail="현재 위치가 보행 네트워크에서 %.0fm 떨어져 있어 경로를 만들 수 없습니다"
-            % s["dist_m"],
+            % min(c[1] for c in o_cands),
         )
+    o_sel, d_sel = _choose_endpoints(H, o_cands, d_cands, profile)
+    s = {"node_id": o_sel[0], "dist_m": round(o_sel[1], 1), "snapped": {"lat": o_sel[2][0], "lng": o_sel[2][1]}, "kind": o_sel[3]}
+    g = {"node_id": d_sel[0], "dist_m": round(d_sel[1], 1), "snapped": {"lat": d_sel[2][0], "lng": d_sel[2][1]}, "kind": d_sel[3]}
 
     relax = True if constraints is None else constraints.relax_if_no_route
     try:
-        result = plan(NET, s["node_id"], g["node_id"], profile, alternatives, relax=relax)
+        result = plan(NET, s["node_id"], g["node_id"], profile, alternatives, relax=relax, graph=H)
     except NoRouteError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-    G = NET.graph
+    G = H
     route_id = "r_%s" % uuid.uuid4().hex[:10]
     routes = []
     for r in result["routes"]:
@@ -262,11 +338,12 @@ def _plan_core(origin_lat, origin_lng, dest: Destination, profile_id: str,
         "profile": profile.id,
         "network_version": NET.meta.get("network_version"),
         "origin": {"lat": origin_lat, "lng": origin_lng,
-                   "snapped": s["snapped"], "snap_dist_m": s["dist_m"]},
+                   "snapped": s["snapped"], "snap_dist_m": s["dist_m"], "snap_kind": s["kind"]},
         "destination": {"type": dest.type, "poi_id": dest.poi_id,
                         "lat": target["lat"], "lng": target["lng"],
                         "resolved_by": target["source"],
-                        "note": _entrance_note(target)},
+                        "note": _entrance_note(target),
+                        "snapped": g["snapped"], "snap_dist_m": g["dist_m"], "snap_kind": g["kind"]},
         "routes": routes,
         "fallback": result["fallback"],
         "data_quality": {
@@ -301,23 +378,28 @@ LOW_BUS_WARNING = ("저상버스 정차 여부는 보장되지 않습니다 — 
                    "실시간 도착정보로 저상 차량을 확인하세요")
 
 
-def _walk_leg(frm, to, profile, allowed, label_from, label_to):
-    """도보 leg 1개 — 기존 보행 라우팅 재사용. 15m 미만은 leg 생략(None)."""
+def _walk_leg(frm, to, profile, allowed, label_from, label_to, to_is_entrance: bool = False):
+    """도보 leg 1개 — 기존 보행 라우팅 재사용. 15m 미만은 leg 생략(None).
+
+    양 끝은 링크 투영 스냅(#67)을 쓴다. 실측 출입구로 해석된 목적지만 노드 스냅(to_is_entrance).
+    """
     straight = transit.haversine_m(frm[0], frm[1], to[0], to[1])
     if straight < 15.0:
         return None
-    s = snap(NET, frm[0], frm[1], profile, settings.snap_max_dist_m, allowed=allowed)
-    g = snap(NET, to[0], to[1], profile, settings.snap_max_dist_m, allowed=allowed)
-    if s["node_id"] == g["node_id"]:
-        return None      # 같은 노드로 스냅되는 지척 이동 — leg 생략
-    result = plan(NET, s["node_id"], g["node_id"], profile, 1, relax=True)
+    H = vsnap.virtual_graph(NET)
+    o_cands = _endpoint_candidates(H, frm[0], frm[1], profile, allowed, "wo")
+    d_cands = _endpoint_candidates(H, to[0], to[1], profile, allowed, "wd", allow_virtual=not to_is_entrance)
+    o_sel, d_sel = _choose_endpoints(H, o_cands, d_cands, profile)
+    if o_sel[0] == d_sel[0]:
+        return None      # 같은 지점으로 스냅되는 지척 이동 — leg 생략
+    result = plan(NET, o_sel[0], d_sel[0], profile, 1, relax=True, graph=H)
     r = result["routes"][0]
     leg = {
         "kind": "walk",
         "from_label": label_from, "to_label": label_to,
         "summary": r["summary"],
         "geometry": r["geometry"],
-        "steps": build_steps(NET.graph, r["path"], profile),
+        "steps": build_steps(H, r["path"], profile),
         "fallback": result["fallback"],
     }
     # 보행망 단절 가능성 — 짧은 직선을 크게 우회하면 위상 문제일 확률이 높다(#30 안양역)
@@ -599,7 +681,9 @@ def _plan_multimodal(origin_lat, origin_lng, dest: Destination, profile_id: str,
             for part in cand["parts"]:
                 if part["kind"] == "walk":
                     leg = _walk_leg(part["frm"][1], part["to"][1], profile, allowed,
-                                    part["frm"][0], part["to"][0])
+                                    part["frm"][0], part["to"][0],
+                                    to_is_entrance=(part["to"][0] == "목적지"
+                                                    and target.get("source") in ENTRANCE_SOURCES))
                     if leg is not None:
                         built.append(leg)
                 elif part["kind"] == "bus":

--- a/route_service/api/main.py
+++ b/route_service/api/main.py
@@ -232,7 +232,13 @@ def _endpoint_candidates(H, lat, lng, profile, allowed, tag: str, allow_virtual:
             nid = vsnap.attach(H, c, "%s%s_%d" % (vsnap.VIRTUAL_PREFIX, tag, i))
             out.append((nid, c["dist_m"], (c["lat"], c["lng"]), "edge"))
     s = snap(NET, lat, lng, profile, settings.snap_max_dist_m, allowed=allowed)
-    out.append((s["node_id"], s["dist_m"], (s["snapped"]["lat"], s["snapped"]["lng"]), "node"))
+    node = (s["node_id"], s["dist_m"], (s["snapped"]["lat"], s["snapped"]["lng"]), "node")
+    # 노드가 좌표 바로 위(≤ 2m)면 그 노드가 정답이고, 노드보다 5m 넘게 먼 링크는 더 나은 접근점이 될 수 없다 —
+    # 그런 후보를 남기면 경로 비용(경사·횡단 가중)이 조금 낮은 먼 접근점이 뽑혀 유턴이 생긴다(실측 2026-09-07)
+    if s["dist_m"] <= vsnap.NODE_EXACT_M:
+        return [node]
+    out = [c for c in out if c[1] <= s["dist_m"] + vsnap.EDGE_OVER_NODE_TOL_M]
+    out.append(node)
     return out
 
 

--- a/route_service/config.py
+++ b/route_service/config.py
@@ -43,6 +43,10 @@ class Settings:
 
     # 탐색 파라미터
     snap_max_dist_m: float = float(os.environ.get("SNAP_MAX_DIST_M", "300"))
+    # 링크 투영 스냅(#67) — 끄면 종전 노드 스냅만 쓴다
+    edge_snap: bool = os.environ.get("EDGE_SNAP", "true").lower() not in ("0", "false", "no")
+    edge_snap_radius_m: float = float(os.environ.get("EDGE_SNAP_RADIUS_M", "60"))
+    edge_snap_k: int = int(os.environ.get("EDGE_SNAP_K", "3"))
     max_alternatives: int = int(os.environ.get("MAX_ALTERNATIVES", "2"))
     off_route_threshold_m: float = float(os.environ.get("OFF_ROUTE_THRESHOLD_M", "30"))
 

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -180,12 +180,13 @@ def _geometry(G, path) -> list:
 
 
 def plan(store, start_node, goal_node, profile: Profile, alternatives: int = 1,
-         relax: bool = True) -> dict:
+         relax: bool = True, graph=None) -> dict:
     """경로 탐색 + 대안 경로.
 
+    graph: 요청 단위 그래프 사본(가상 노드 포함, engine.vsnap) — 없으면 store.graph.
     반환: {"routes": [...], "fallback": {...}}
     """
-    G = store.graph
+    G = graph if graph is not None else store.graph
     if start_node == goal_node:
         raise NoRouteError("출발지와 목적지가 같은 지점입니다")
 

--- a/route_service/engine/planner.py
+++ b/route_service/engine/planner.py
@@ -57,10 +57,17 @@ def _uturn_edges(G, path) -> set:
     return edges
 
 
+DERIVED_COST_LAMBDA = 4.0     # 정제 링크 비용 = length × (1 + λ(1 − confidence)) — 증거가 쌓이면 스스로 이긴다
+
+
 def edge_passable(data: dict, profile: Profile, max_slope_deg: float) -> bool:
     if data.get("blocked"):
         # 제보·실측 오버라이드(passable=false, engine.overrides) — 승인제로만 설정된다
         return False
+    conf = data.get("confidence")
+    if conf is not None and data.get("topo_source") == "derived" \
+            and float(conf) < float(getattr(profile, "derived_min_confidence", 0.0) or 0.0):
+        return False          # 정제 링크 활성 하한 미달 — 이 프로필에는 없는 링크 (v1.23.0)
     if data["link_type"] in profile.avoid:
         return False
     # max_slope_deg 는 하드 상한(profile.hard_slope() 또는 완화 단계). 짧은 링크는 경사로 막지 않는다 (v1.20.0)
@@ -84,6 +91,9 @@ def edge_cost(data: dict, profile: Profile, penalty: float = 1.0) -> float:
         # 권장 초과 구간은 우회로가 있으면 피하되, 우회가 몇 배로 길어지면 그냥 지난다 (v1.20.0)
         cost *= 1.0 + float(getattr(profile, "slope_over_penalty", 1.0)) * over
     cost *= profile.penalize.get(data["link_type"], 1.0)
+    conf = data.get("confidence")
+    if conf is not None and data.get("topo_source") == "derived":
+        cost *= 1.0 + DERIVED_COST_LAMBDA * (1.0 - float(conf))
     return cost * penalty
 
 

--- a/route_service/engine/profiles.py
+++ b/route_service/engine/profiles.py
@@ -33,6 +33,9 @@ class Profile:
     requires_curb_cut: bool = False
     hard_slope_deg: float = 0.0          # 0 = max_slope_deg 와 동일 (v1.20.0)
     slope_over_penalty: float = 1.0      # 권장 초과 1도당 비용 가중 배수 증가분 (v1.20.0)
+    # 정제로 신설된 직결 링크(topo_source='derived')의 활성 하한 (v1.23.0, #67).
+    # 링크 속성 confidence 가 이 값 미만이면 이 프로필에는 존재하지 않는 링크다.
+    derived_min_confidence: float = 0.40
 
     def hard_slope(self) -> float:
         """통행 불가 경사 상한 — 권장 상한보다 낮게는 잡히지 않는다(제약으로 max 를 올리면 같이 올라간다)."""
@@ -48,6 +51,7 @@ class Profile:
             "avoid": list(self.avoid),
             "min_width_m": self.min_width_m,
             "requires_curb_cut": self.requires_curb_cut,
+            "derived_min_confidence": self.derived_min_confidence,
         }
 
 
@@ -66,6 +70,7 @@ PROFILES = {
         requires_curb_cut=True,
         hard_slope_deg=8.0,
         slope_over_penalty=1.0,
+        derived_min_confidence=0.60,
     ),
     "wheelchair_electric": Profile(
         id="wheelchair_electric",
@@ -79,6 +84,7 @@ PROFILES = {
         requires_curb_cut=True,
         hard_slope_deg=10.0,
         slope_over_penalty=0.6,
+        derived_min_confidence=0.55,
     ),
     "crutch": Profile(
         id="crutch",
@@ -99,6 +105,7 @@ PROFILES = {
         avoid=(),
         penalize={"crossing": 1.5, "overpass": 2.0, "underpass": 1.5},
         min_width_m=0.0,
+        derived_min_confidence=0.70,
     ),
     "walk": Profile(
         id="walk",

--- a/route_service/engine/vsnap.py
+++ b/route_service/engine/vsnap.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""링크 투영 스냅 — 출발·도착 좌표를 최근접 **링크 위의 점**에 가상 노드로 붙인다 (#67, v1.23.0).
+
+종전 `snap.snap()` 은 최근접 **노드**에만 붙였다. 링크 길이 중앙값 47m, 100m 초과 링크가
+2,250개인 그래프에서는 좌표가 긴 링크 중간에 있으면 링크 한쪽 끝까지 갔다가 되돌아오는
+경로가 구조적으로 나온다(실측: 안양아트센터 노드 60.4m 대 링크 위 점 35.5m, 우회비 1.55).
+
+가상 노드는 공유 그래프를 건드리지 않는다 — 요청마다 그래프 사본(`attach()`)에 노드와
+분할 링크 두 개를 얹고, 원 링크는 그대로 둔다(다른 경로에 영향 없음).
+
+안전 필터 (교차검토 2026-09-07):
+  · 계층 스냅 — 반경 LAYER_RADIUS_M 안에 보행 링크(sidewalk 계열)가 있으면 도로 링크는 후보에서 뺀다.
+    간선(primary/secondary/trunk 로 재분류된 link_name 이 없으므로 link_type=='road' 전체를 2순위로 둔다)
+  · crossing·steps·overpass·underpass 링크는 투영 대상에서 제외 — 차도 한복판·계단 위에서 안내가 시작되면 안 된다
+  · LOS — 좌표→투영점 선분이 건물 폴리곤 또는 옹벽·담장(ObstacleIndex)과 교차하면 탈락
+  · K 후보 — 상위 K 개 링크에 각각 투영해 두고, 호출 측이 "투영 거리 + 목적지까지 경로 비용" 최소를 고른다
+
+실측 출입구(manual_survey·accessible_entrance)로 해석된 도착점은 종전 노드 스냅을 유지한다 —
+출입구 스퍼 끝 노드가 곧 안내 종점이어야 하기 때문이다(호출 측 판단).
+"""
+from __future__ import annotations
+
+import math
+
+from .geo import haversine_m
+from .planner import edge_passable
+
+VIRTUAL_PREFIX = "V_"
+DEFAULT_RADIUS_M = 60.0          # 투영 후보를 찾는 반경 (노드 스냅 상한 300m 보다 훨씬 작게 — 먼 링크는 노드 스냅이 맡는다)
+LAYER_RADIUS_M = 20.0            # 이 안에 보행 링크가 있으면 도로 링크 제외
+DEFAULT_K = 3
+PEDESTRIAN_TYPES = ("sidewalk", "footway", "path", "pedestrian", "living_street", "derived")
+NO_PROJECT_TYPES = ("crossing", "steps", "overpass", "underpass")
+MIN_SPLIT_M = 1.0                # 링크 끝에서 이보다 가까우면 그냥 그 끝 노드로 본다
+
+_KY = 110_540.0
+
+
+def _kx(lat):
+    return 111_320.0 * math.cos(math.radians(lat))
+
+
+def _project(lat, lng, a, b):
+    """점을 선분 a-b((lat,lon))에 투영. (거리 m, t, (lat,lon))"""
+    kx, ky = _kx(lat), _KY
+    ax, ay = (a[1] - lng) * kx, (a[0] - lat) * ky
+    bx, by = (b[1] - lng) * kx, (b[0] - lat) * ky
+    dx, dy = bx - ax, by - ay
+    l2 = dx * dx + dy * dy
+    t = 0.0 if l2 == 0 else max(0.0, min(1.0, -(ax * dx + ay * dy) / l2))
+    px, py = ax + t * dx, ay + t * dy
+    return math.hypot(px, py), t, (lat + py / ky, lng + px / kx)
+
+
+def _segments(G, u, v):
+    """링크의 좌표열을 (시작좌표, 끝좌표, 누적길이m) 선분 목록으로."""
+    from .graph import edge_coords
+    coords = edge_coords(G, u, v)
+    out, acc = [], 0.0
+    for a, b in zip(coords[:-1], coords[1:]):
+        seg = haversine_m(a[0], a[1], b[0], b[1])
+        out.append((a, b, acc, seg))
+        acc += seg
+    return out, acc
+
+
+class LineOfSight:
+    """좌표→투영점 선분이 건물·옹벽·담장을 가로지르는지. 색인이 없으면 항상 통과."""
+
+    def __init__(self, buildings=None, obstacles=None):
+        self.buildings = buildings if (buildings is not None and getattr(buildings, "loaded", False)) else None
+        self.obstacles = obstacles
+        self._btree = None
+
+    def _building_tree(self):
+        if self._btree is None and self.buildings is not None:
+            try:
+                from shapely.strtree import STRtree
+                self._bgeoms = [p for p, _n in self.buildings.polys]
+                self._btree = STRtree(self._bgeoms)
+            except Exception:
+                self._btree = False
+        return self._btree
+
+    def blocked(self, p_lat, p_lng, q_lat, q_lng) -> bool:
+        if self.buildings is None and self.obstacles is None:
+            return False
+        try:
+            from shapely.geometry import LineString
+        except Exception:
+            return False
+        line = LineString([(p_lng, p_lat), (q_lng, q_lat)])
+        if line.length == 0:
+            return False
+        tree = self._building_tree()
+        if tree:
+            for i in tree.query(line):
+                g = self._bgeoms[i]
+                # 좌표 자체가 건물 안(출입구·대표점)인 경우는 건물 경계를 한 번 나가는 것이라 허용
+                if g.crosses(line) and not (g.contains(line.interpolate(0)) or g.contains(line.interpolate(1, normalized=True))):
+                    return True
+        if self.obstacles is not None:
+            try:
+                if self.obstacles.crosses_barrier(line):
+                    return True
+            except Exception:
+                return False
+        return False
+
+
+def candidates(store, lat, lng, profile, max_slope_deg, allowed=None, radius_m=DEFAULT_RADIUS_M,
+               k=DEFAULT_K, los: LineOfSight | None = None) -> list:
+    """투영 후보 목록(가까운 순, 최대 k).
+
+    각 항목: {"u","v","t","lat","lng","dist_m","link_type","seg_index"}.
+    후보가 없으면 빈 목록 — 호출 측은 노드 스냅으로 폴백한다.
+    """
+    G = store.graph
+    node_ids, coords = store.node_index
+    # 반경 안 노드에 붙은 링크만 본다(전 링크 투영은 불필요)
+    kx = _kx(lat)
+    near_nodes = []
+    for nid, (nlat, nlon) in zip(node_ids, coords):
+        if abs(nlat - lat) * _KY > radius_m * 4 or abs(nlon - lng) * kx > radius_m * 4:
+            continue
+        near_nodes.append(nid)
+    seen, cands = set(), []
+    for n in near_nodes:
+        for m, data in G[n].items():
+            key = frozenset((n, m))
+            if key in seen:
+                continue
+            seen.add(key)
+            lt = data.get("link_type")
+            if lt in NO_PROJECT_TYPES:
+                continue
+            if not edge_passable(data, profile, max_slope_deg):
+                continue
+            if allowed and (n not in allowed and m not in allowed):
+                continue
+            segs, total = _segments(G, n, m)
+            best = None
+            for i, (a, b, acc, seg) in enumerate(segs):
+                d, t, p = _project(lat, lng, a, b)
+                if best is None or d < best[0]:
+                    best = (d, acc + t * seg, p, i)
+            if best is None or best[0] > radius_m:
+                continue
+            d, along, p, si = best
+            t_link = 0.0 if total <= 0 else max(0.0, min(1.0, along / total))
+            cands.append({"u": n, "v": m, "t": t_link, "lat": p[0], "lng": p[1], "dist_m": d,
+                          "link_type": lt, "seg_index": si, "length": total})
+    if not cands:
+        return []
+    # 계층 스냅 — 보행 링크가 가까이 있으면 도로 링크 제외
+    if any(c["link_type"] in PEDESTRIAN_TYPES and c["dist_m"] <= LAYER_RADIUS_M for c in cands):
+        cands = [c for c in cands if c["link_type"] in PEDESTRIAN_TYPES or c["link_type"] != "road"]
+    # LOS
+    if los is not None:
+        cands = [c for c in cands if not los.blocked(lat, lng, c["lat"], c["lng"])]
+    cands.sort(key=lambda c: c["dist_m"])
+    return cands[:k]
+
+
+def attach(H, cand: dict, node_id: str) -> str:
+    """그래프 사본 H 에 가상 노드와 분할 링크 두 개를 얹는다. 원 링크는 유지.
+
+    링크 끝에서 MIN_SPLIT_M 이내면 가상 노드를 만들지 않고 그 끝 노드 id 를 돌려준다.
+    """
+    G = H
+    u, v, t = cand["u"], cand["v"], cand["t"]
+    total = float(cand.get("length") or G[u][v].get("length") or 0.0)
+    if total <= 0 or t * total < MIN_SPLIT_M:
+        return u
+    if (1.0 - t) * total < MIN_SPLIT_M:
+        return v
+    from .graph import edge_coords
+    data = dict(G[u][v])
+    coords = edge_coords(G, u, v)
+    # 좌표열을 투영점에서 자른다
+    si = cand["seg_index"]
+    p = (cand["lat"], cand["lng"])
+    head = coords[:si + 1] + [p]
+    tail = [p] + coords[si + 1:]
+    G.add_node(node_id, lat=p[0], lon=p[1], node_type="virtual", virtual=True)
+    d1 = dict(data); d1["length"] = max(t * total, 0.1); d1["geometry"] = head if len(head) > 2 else None
+    d2 = dict(data); d2["length"] = max((1.0 - t) * total, 0.1); d2["geometry"] = tail if len(tail) > 2 else None
+    G.add_edge(u, node_id, **d1)
+    G.add_edge(node_id, v, **d2)
+    return node_id
+
+
+def virtual_graph(store):
+    """요청 단위 그래프 사본 — 노드·링크 속성 dict 는 얕게 복사된다."""
+    return store.graph.copy()

--- a/route_service/engine/vsnap.py
+++ b/route_service/engine/vsnap.py
@@ -32,6 +32,8 @@ DEFAULT_K = 3
 PEDESTRIAN_TYPES = ("sidewalk", "footway", "path", "pedestrian", "living_street", "derived")
 NO_PROJECT_TYPES = ("crossing", "steps", "overpass", "underpass")
 MIN_SPLIT_M = 1.0                # 링크 끝에서 이보다 가까우면 그냥 그 끝 노드로 본다
+NODE_EXACT_M = 2.0               # 노드가 이 안에 있으면 노드 스냅만 쓴다
+EDGE_OVER_NODE_TOL_M = 5.0       # 노드 스냅 거리보다 이만큼 넘게 먼 링크 후보는 버린다
 
 _KY = 110_540.0
 

--- a/route_service/topomap/obstacles.py
+++ b/route_service/topomap/obstacles.py
@@ -115,6 +115,24 @@ class ObstacleIndex:
         buf = line.buffer(clearance_m / _kx(line.centroid.y))
         return bool(self._hits(FURNITURE, buf))
 
+    def furniture_gap_below(self, line, gap_m: float = 0.8, search_m: float = 2.0) -> bool:
+        """선분 근처 점형 지물(볼라드·가로수)과 다른 지물·옹벽·담장 사이 통과 간격이 gap_m 미만인가 (#67 H12)."""
+        lat = line.centroid.y
+        near = self._hits(FURNITURE, line.buffer(search_m / _kx(lat)))
+        if not near:
+            return False
+        others = []
+        for klass in (WALL, FENCE, FURNITURE):
+            others += self._hits(klass, line.buffer((search_m + gap_m) / _kx(lat)))
+        tol = gap_m / _kx(lat)
+        for p in near:
+            for o in others:
+                if o is p:
+                    continue
+                if 0 < p.distance(o) < tol:
+                    return True
+        return False
+
     def blocks_new_link(self, line) -> str | None:
         """신설 링크 하드 게이트. 배제 사유 문자열, 통과면 None."""
         if self.crosses_stairs(line, min_m=0.5):

--- a/route_service/topomap/refine.py
+++ b/route_service/topomap/refine.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""우회 삼각형 직결 링크 정제 (#67, v1.23.0).
+
+A–M, M–B 인접 링크는 있는데 A–B 직결이 없어 짧은 거리를 크게 우회하는 지점에, 규칙만으로
+직결 링크를 신설한다. 사람 검수는 없다 — 안전은 하드 게이트가, 선호는 신뢰도(비용)가 맡는다.
+(설계서 90-리포트_아카이브/보행망_우회삼각형_자동정제_설계_2026-09-04.md, 교차검토 2026-09-07)
+
+  후보   : 차수 무관. 우회비(경로/직선) ≥ 1.41, 우회량(경로−직선) < 20m, 직선 ≤ 25m
+  하드   : H1 인도 면형 밖(간격 0.3m 흡수) · H3/H4/H6 계단·옹벽·담장·가로시설물(ObstacleIndex)
+           · H8 신설선 종단경사 > 8° · H9 25m 초과 · H10 고도차 > 1m & 인접 경사 > 5%(지그재그 경사로)
+           · H11 우회 구간이 횡단보도 링크 · H12 점형 지물 통과 간격 < 0.8m
+  신뢰도 : 1.0 에서 곱셈 감점 — 인셋 0.2m 밖 ×0.55 · 회랑폭 1.5m 미만 ×0.70 · 파편화(A·B 다른 폴리곤,
+           **맞닿지 않은** 경우만) ×0.60 · 접합각 60° 미만 ×0.70
+  반영   : topo_source='derived', confidence=c. 활성은 프로필별 하한(planner.edge_passable)이 판단한다.
+           링크는 **추가만** 한다 — 기존 링크(지그재그 경사로 포함)는 절대 지우지 않는다.
+
+산식 정정 근거 (2026-09-07): 1:1000 도화 허용오차 0.2~0.5m 에 0.5m 인셋을 양쪽에 주면 1.5m 표준
+보도의 유효폭이 0.5m 만 남아 정상 링크도 떨어진다. 휠체어 반폭 0.35m + 도화 오차 → 0.2m.
+도엽 경계에서 맞닿은 두 폴리곤(간격 ≤ 0.1m)은 실제 단절이 아니다.
+"""
+from __future__ import annotations
+
+import math
+
+from ..engine.geo import haversine_m
+
+RATIO_MIN = 1.41
+DETOUR_MAX_M = 20.0
+NEW_LINK_MAX_M = 25.0
+GAP_TOL_M = 0.3            # 인도 폴리곤 도엽 sliver gap 흡수 (H1)
+INSET_M = 0.2              # 경계 인셋 감점 기준 (0.5 → 0.2)
+TOUCH_TOL_M = 0.1          # 두 폴리곤이 이 간격 안이면 '맞닿음' — 파편화 감점 면제
+END_TRIM_M = 1.0           # 인셋 판정에서 제외하는 양 끝 길이(끝점은 기존 노드)
+MIN_WIDTH_M = 1.5
+HARD_SLOPE_DEG = 8.0
+ZIGZAG_DZ_M = 1.0
+ZIGZAG_SLOPE_PCT = 5.0
+BOLLARD_GAP_M = 0.8
+ANGLE_MIN_DEG = 60.0
+CROSSING_TYPES = ("crossing",)
+
+_KY = 110_540.0
+
+
+def _kx(lat):
+    return 111_320.0 * math.cos(math.radians(lat))
+
+
+def _bearing(a, b):
+    """(lat,lon) a→b 방위각(도)."""
+    dy = (b[0] - a[0]) * _KY
+    dx = (b[1] - a[1]) * _kx(a[0])
+    return math.degrees(math.atan2(dx, dy)) % 360.0
+
+
+def _angle_between(b1, b2):
+    d = abs(b1 - b2) % 360.0
+    return min(d, 360.0 - d)
+
+
+class SidewalkIndex:
+    """인도 면형 색인 — covers/인셋/파편화/폭 판정."""
+
+    def __init__(self, features: list):
+        from shapely.strtree import STRtree
+        self.geoms = [f["geom"] for f in features]
+        self.widths = [f.get("width") for f in features]
+        self.tree = STRtree(self.geoms) if self.geoms else None
+
+    def _deg(self, m, lat):
+        return m / _kx(lat)
+
+    def _hits(self, geom):
+        if self.tree is None:
+            return []
+        return [int(i) for i in self.tree.query(geom) if self.geoms[int(i)].intersects(geom)]
+
+    def covers_line(self, line, tol_m=GAP_TOL_M) -> bool:
+        """선분이 인도 면형(합집합, 간격 tol 흡수) 안에 완전히 들어가는가 (H1)."""
+        from shapely.ops import unary_union
+        # 폴리곤을 tol/2 씩 부풀리면 tol 까지의 틈이 닫힌다 (도엽 경계 sliver 흡수, 그 이상은 실제 단절)
+        half = self._deg(tol_m / 2.0, line.centroid.y)
+        idx = self._hits(line.buffer(half))
+        if not idx:
+            return False
+        union = unary_union([self.geoms[i].buffer(half) for i in idx])
+        return union.covers(line)
+
+    def inside_inset(self, line, inset_m=INSET_M) -> bool:
+        """경계에서 inset 만큼 안쪽 영역에도 들어가는가 (감점 항목)."""
+        from shapely.geometry import LineString
+        from shapely.ops import unary_union
+        half = self._deg(GAP_TOL_M / 2.0, line.centroid.y)
+        idx = self._hits(line.buffer(half))
+        if not idx:
+            return False
+        # 닫힘(closing: +tol/2 → −tol/2)으로 도엽 경계 이음새를 지운 뒤, 바깥 경계 기준 inset 만큼 안쪽으로.
+        # (부풀린 채로 크게 깎으면 이음새가 다시 벌어져 정상 링크가 인셋 밖으로 판정된다 — 실측 2026-09-07)
+        closed = unary_union([self.geoms[i].buffer(half) for i in idx]).buffer(-half)
+        inner = closed.buffer(-self._deg(inset_m, line.centroid.y))
+        if inner.is_empty:
+            return False
+        # 양 끝 END_TRIM_M 은 뺀다 — 끝점은 이미 보행망이 쓰는 노드이고, 접속 노드는 흔히 폴리곤 경계 위에
+        # 놓인다(실측: 안양문화원 앞 A 노드 경계 거리 0.00m). 인셋은 신설선 **내부**의 여유폭을 보는 것이다.
+        L = line.length
+        trim = min(self._deg(END_TRIM_M, line.centroid.y), L * 0.2)
+        core = LineString([line.interpolate(trim), line.interpolate(L - trim)]) if L > 2 * trim else line
+        return inner.covers(core)
+
+    def fragmented(self, p_a, p_b) -> bool:
+        """A·B 가 서로 다른 폴리곤에 속하고 그 폴리곤들이 맞닿아 있지 않은가."""
+        from shapely.geometry import Point
+        ia = set(self._hits(Point(p_a[1], p_a[0]).buffer(self._deg(GAP_TOL_M, p_a[0]))))
+        ib = set(self._hits(Point(p_b[1], p_b[0]).buffer(self._deg(GAP_TOL_M, p_b[0]))))
+        if not ia or not ib or (ia & ib):
+            return False
+        tol = self._deg(TOUCH_TOL_M, p_a[0])
+        for i in ia:
+            for j in ib:
+                if self.geoms[i].distance(self.geoms[j]) <= tol:
+                    return False        # 맞닿음 — 도엽 경계일 뿐
+        return True
+
+    def min_width(self, line):
+        idx = self._hits(line)
+        ws = [self.widths[i] for i in idx if self.widths[i]]
+        return min(ws) if ws else None
+
+    @classmethod
+    def from_geojson(cls, path: str) -> "SidewalkIndex":
+        import json
+        from shapely.geometry import shape
+        with open(path, encoding="utf-8") as fp:
+            fc = json.load(fp)
+        feats = []
+        for f in fc.get("features", []):
+            g = shape(f["geometry"])
+            if not g.is_valid:
+                g = g.buffer(0)
+            if g.is_empty:
+                continue
+            feats.append({"geom": g, "width": (f.get("properties") or {}).get("width")})
+        return cls(feats)
+
+
+def find_candidates(G) -> list:
+    """직결 링크가 없는 A–M–B 삼각형. 차수 제한 없음."""
+    out, seen = [], set()
+    for m in G.nodes:
+        nbrs = list(G[m])
+        if len(nbrs) < 2:
+            continue
+        pm = (G.nodes[m]["lat"], G.nodes[m]["lon"])
+        for i in range(len(nbrs)):
+            for j in range(i + 1, len(nbrs)):
+                a, b = nbrs[i], nbrs[j]
+                if G.has_edge(a, b):
+                    continue
+                key = (min(str(a), str(b)), max(str(a), str(b)), str(m))
+                if key in seen:
+                    continue
+                seen.add(key)
+                pa = (G.nodes[a]["lat"], G.nodes[a]["lon"]); pb = (G.nodes[b]["lat"], G.nodes[b]["lon"])
+                straight = haversine_m(pa[0], pa[1], pb[0], pb[1])
+                if straight <= 0.5 or straight > NEW_LINK_MAX_M:
+                    continue
+                via = float(G[a][m].get("length") or 0) + float(G[m][b].get("length") or 0)
+                if via <= 0:
+                    continue
+                ratio = via / straight
+                if ratio < RATIO_MIN or via - straight >= DETOUR_MAX_M:
+                    continue
+                out.append({"a": a, "m": m, "b": b, "pa": pa, "pb": pb, "pm": pm,
+                            "straight_m": straight, "via_m": via, "ratio": ratio,
+                            "type_am": G[a][m].get("link_type"), "type_mb": G[m][b].get("link_type")})
+    return out
+
+
+def _node_elev(G, n, dem):
+    if dem is not None:
+        try:
+            z = dem.elevation(G.nodes[n]["lat"], G.nodes[n]["lon"])
+            if z is not None:
+                return float(z)
+        except Exception:
+            pass
+    return None
+
+
+def hard_gate(G, c: dict, sidewalks: SidewalkIndex, obstacles, dem=None) -> str | None:
+    """배제 사유 문자열, 통과면 None."""
+    from shapely.geometry import LineString
+    a, m, b = c["a"], c["m"], c["b"]
+    line = LineString([(c["pa"][1], c["pa"][0]), (c["pb"][1], c["pb"][0])])
+    if c["straight_m"] > NEW_LINK_MAX_M:
+        return "H9 25m 초과"
+    # H11: 우회 구간(A–M·M–B) 자체가 횡단보도 링크면 신설선이 유도선·진입 경사로를 건너뛴다.
+    # A·B 가 다른 횡단보도에 접해 있는 것만으로는 배제하지 않는다 — 보도 안 여부는 H1 이 본다.
+    if c.get("type_am") in CROSSING_TYPES or c.get("type_mb") in CROSSING_TYPES:
+        return "H11 횡단보도 링크 우회"
+    if not sidewalks.covers_line(line):
+        return "H1 인도 면형 밖"
+    if obstacles is not None:
+        why = obstacles.blocks_new_link(line)
+        if why:
+            return "H3/H4/H6 " + why
+        try:
+            if obstacles.furniture_gap_below(line, BOLLARD_GAP_M):
+                return "H12 점형 지물 통과 간격 부족"
+        except AttributeError:
+            pass
+    za, zb = _node_elev(G, a, dem), _node_elev(G, b, dem)
+    if za is not None and zb is not None:
+        dz = abs(za - zb)
+        slope = math.degrees(math.atan2(dz, max(c["straight_m"], 0.1)))
+        c["slope_deg"] = round(slope, 2)
+        if slope > HARD_SLOPE_DEG:
+            return "H8 종단경사 %.1f도" % slope
+        if dz > ZIGZAG_DZ_M:
+            for u, v in ((a, m), (m, b)):
+                if float(G[u][v].get("slope") or 0) > math.degrees(math.atan(ZIGZAG_SLOPE_PCT / 100.0)):
+                    return "H10 지그재그 경사로"
+    return None
+
+
+def confidence(G, c: dict, sidewalks: SidewalkIndex, dem=None) -> tuple:
+    """(c0, 감점 사유 목록)"""
+    from shapely.geometry import LineString
+    a, m, b = c["a"], c["m"], c["b"]
+    line = LineString([(c["pa"][1], c["pa"][0]), (c["pb"][1], c["pb"][0])])
+    val, why = 1.0, []
+    if not sidewalks.inside_inset(line):
+        val *= 0.55; why.append("인셋 %.1fm 밖" % INSET_M)
+    w = sidewalks.min_width(line)
+    if w is not None and w < MIN_WIDTH_M:
+        val *= 0.70; why.append("폭 %.1fm" % w)
+    if sidewalks.fragmented(c["pa"], c["pb"]):
+        val *= 0.60; why.append("파편화(비접촉)")
+    # 고도차 감점은 두지 않는다 — 신설선의 양 끝은 우회로 A–M–B 의 양 끝과 같은 점이라 고도차가 항상 같다.
+    # 단차·계단 위험은 H8(종단경사)·H10(지그재그)·H4(계단 면형)가 본다. (2026-09-07 정정)
+    # 접합각 — A·B 에서 신설 링크와 (A–M·M–B 를 뺀) 다른 링크 사이 최소 각
+    bab = _bearing(c["pa"], c["pb"])
+    worst = None
+    for n, other, base in ((a, b, bab), (b, a, (bab + 180.0) % 360.0)):
+        for x in G[n]:
+            if x == m:
+                continue
+            ang = _angle_between(base, _bearing((G.nodes[n]["lat"], G.nodes[n]["lon"]),
+                                                 (G.nodes[x]["lat"], G.nodes[x]["lon"])))
+            worst = ang if worst is None else min(worst, ang)
+    if worst is not None and worst < ANGLE_MIN_DEG:
+        val *= 0.70; why.append("접합각 %.0f도" % worst)
+    return round(val, 3), why
+
+
+def refine(G, sidewalks: SidewalkIndex, obstacles=None, dem=None) -> dict:
+    """전체 파이프라인. 반환 {"candidates": [...], "adopted": [...], "reasons": Counter}"""
+    from collections import Counter
+    cands = find_candidates(G)
+    reasons, adopted = Counter(), []
+    for c in cands:
+        why = hard_gate(G, c, sidewalks, obstacles, dem)
+        c["gate"] = why
+        if why:
+            reasons[why.split(" ")[0]] += 1
+            continue
+        c0, pen = confidence(G, c, sidewalks, dem)
+        c["confidence"], c["penalties"] = c0, pen
+        adopted.append(c)
+    reasons["adopted"] = len(adopted)
+    return {"candidates": cands, "adopted": adopted, "reasons": reasons}
+
+
+def apply(G, adopted: list, min_confidence: float = 0.0) -> int:
+    """채택 후보를 그래프에 **추가**한다. 속성은 A–M 링크를 상속(길이·경사·지오메트리는 새로)."""
+    n = 0
+    for c in adopted:
+        if c["confidence"] < min_confidence or G.has_edge(c["a"], c["b"]):
+            continue
+        base = dict(G[c["a"]][c["m"]])
+        za, zb = base.get("elev_start"), base.get("elev_end")
+        data = {k: v for k, v in base.items() if k not in ("geometry", "cw_mgmt_no", "cw_length_m", "stitched", "bridged")}
+        data.update({"length": float(c["straight_m"]), "geometry": None,
+                     "slope": float(c.get("slope_deg") or 0.0),
+                     "topo_source": "derived", "confidence": float(c["confidence"]),
+                     "derived_via": str(c["m"]), "link_type": base.get("link_type") or "sidewalk"})
+        if data["link_type"] in ("crossing", "steps", "overpass", "underpass"):
+            data["link_type"] = "sidewalk"
+        G.add_edge(c["a"], c["b"], **data)
+        n += 1
+    return n

--- a/scripts/build_topomap_layers.py
+++ b/scripts/build_topomap_layers.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""수치지형도(1:1000) 도엽에서 정제·스냅에 쓰는 면형 레이어를 한 번 뽑아 둔다 (#67, v1.23.0).
+
+산출 (WGS84 GeoJSON):
+  <out>/sidewalk_polys.geojson   인도 면형(A0033320) — 폭·도엽 id 속성. 직결 링크 정제(H1·인셋·파편화)에 쓴다
+  <out>/obstacles.geojson        계단 면형·옹벽·담장·가드펜스·수목 (topomap.obstacles.ObstacleIndex 직렬화)
+
+    python scripts/build_topomap_layers.py --src "<도엽 폴더>" --out data/topomap_layers
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from route_service.topomap.extract import extract_sheet  # noqa: E402
+from route_service.topomap.obstacles import build_index  # noqa: E402
+
+SRC_EPSG = 5186
+
+
+def _sheets(src: str) -> list[str]:
+    out = sorted(glob.glob(os.path.join(src, "**", "*.zip"), recursive=True))
+    seen, uniq = set(), []
+    for p in out:
+        m = re.search(r"_(\d{9})_", os.path.basename(p))
+        k = m.group(1) if m else p
+        if k in seen:
+            continue
+        seen.add(k)
+        uniq.append(p)
+    return uniq
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True)
+    ap.add_argument("--out", default="data/topomap_layers")
+    ap.add_argument("--limit", type=int)
+    a = ap.parse_args()
+    from pyproj import Transformer
+    from shapely.geometry import Polygon, mapping
+    from shapely.ops import transform
+    fwd = Transformer.from_crs(f"EPSG:{SRC_EPSG}", "EPSG:4326", always_xy=True).transform
+
+    sheets = _sheets(a.src)
+    if a.limit:
+        sheets = sheets[:a.limit]
+    os.makedirs(a.out, exist_ok=True)
+    t0 = time.time()
+    feats = []
+    for i, p in enumerate(sheets):
+        for f in extract_sheet(p):
+            if f.get("kind") != "sidewalk_poly":
+                continue
+            pts, parts = f["points"], list(f["parts"]) + [len(f["points"])]
+            rings = [pts[parts[j]:parts[j + 1]] for j in range(len(parts) - 1)]
+            rings = [r for r in rings if len(r) >= 4]
+            if not rings:
+                continue
+            try:
+                poly = Polygon(rings[0], rings[1:])
+                if not poly.is_valid:
+                    poly = poly.buffer(0)
+                if poly.is_empty:
+                    continue
+                g = transform(lambda x, y, z=None: fwd(x, y), poly)
+            except Exception:
+                continue
+            attrs = f.get("attrs") or {}
+            w = attrs.get("폭") or attrs.get("WIDTH")
+            try:
+                w = float(str(w).strip()) if w not in (None, "") else None
+            except ValueError:
+                w = None
+            feats.append({"type": "Feature", "properties": {"sheet": f["sheet"], "width": w},
+                          "geometry": mapping(g)})
+        if (i + 1) % 20 == 0:
+            print("  sidewalk %d/%d sheets, %d polys, %.0fs" % (i + 1, len(sheets), len(feats), time.time() - t0), flush=True)
+    with open(os.path.join(a.out, "sidewalk_polys.geojson"), "w", encoding="utf-8") as fp:
+        json.dump({"type": "FeatureCollection", "features": feats}, fp)
+    print("sidewalk_polys: %d (%.0fs)" % (len(feats), time.time() - t0), flush=True)
+
+    idx = build_index(sheets, to_wgs84=fwd)
+    n = idx.to_geojson(os.path.join(a.out, "obstacles.geojson"))
+    print("obstacles: %d %s (%.0fs)" % (n, idx.counts(), time.time() - t0), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refine_detour_links.py
+++ b/scripts/refine_detour_links.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""우회 삼각형 직결 링크 정제 실행 (#67, v1.23.0).
+
+    python scripts/refine_detour_links.py --graph data/network_anyang_hybrid.gpickle \\
+        --layers data/topomap_layers --dem data/dem/anyang_5m.tif \\
+        --out data/network_anyang_hybrid_r1.gpickle --report data/refine_report.csv --version anyang-hybrid-2026Q3r1
+
+--layers 는 scripts/build_topomap_layers.py 산출(sidewalk_polys.geojson, obstacles.geojson).
+--out 을 주지 않으면 보고서만 낸다. 활성 하한은 런타임 프로필이 판단하므로 채택분은 전부 넣는다(--min-confidence 로 제한 가능).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import pickle
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from route_service.topomap import refine as rf  # noqa: E402
+from route_service.topomap.obstacles import ObstacleIndex  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", required=True)
+    ap.add_argument("--layers", required=True)
+    ap.add_argument("--dem")
+    ap.add_argument("--out")
+    ap.add_argument("--report", default="data/refine_report.csv")
+    ap.add_argument("--version")
+    ap.add_argument("--min-confidence", type=float, default=0.0)
+    a = ap.parse_args()
+    t0 = time.time()
+    with open(a.graph, "rb") as f:
+        G = pickle.load(f)
+    sw = rf.SidewalkIndex.from_geojson(os.path.join(a.layers, "sidewalk_polys.geojson"))
+    ob = ObstacleIndex.from_geojson(os.path.join(a.layers, "obstacles.geojson"))
+    dem = None
+    if a.dem:
+        from route_service.engine.dem import DemSampler
+        dem = DemSampler(a.dem)
+    print("graph %d/%d, sidewalk polys %d, obstacles %s (%.0fs)" % (
+        G.number_of_nodes(), G.number_of_edges(), len(sw.geoms), ob.counts(), time.time() - t0), flush=True)
+    res = rf.refine(G, sw, ob, dem)
+    print("candidates %d → %s (%.0fs)" % (len(res["candidates"]), dict(res["reasons"]), time.time() - t0), flush=True)
+    os.makedirs(os.path.dirname(os.path.abspath(a.report)), exist_ok=True)
+    with open(a.report, "w", newline="", encoding="utf-8") as fp:
+        w = csv.writer(fp)
+        w.writerow(["a", "m", "b", "lat_a", "lon_a", "lat_b", "lon_b", "straight_m", "via_m", "ratio",
+                    "type_am", "type_mb", "gate", "confidence", "penalties", "slope_deg"])
+        for c in res["candidates"]:
+            w.writerow([c["a"], c["m"], c["b"], "%.7f" % c["pa"][0], "%.7f" % c["pa"][1], "%.7f" % c["pb"][0], "%.7f" % c["pb"][1],
+                        "%.1f" % c["straight_m"], "%.1f" % c["via_m"], "%.2f" % c["ratio"], c["type_am"], c["type_mb"],
+                        c.get("gate") or "", c.get("confidence", ""), "|".join(c.get("penalties", [])), c.get("slope_deg", "")])
+    ad = res["adopted"]
+    if ad:
+        import statistics
+        cs = [c["confidence"] for c in ad]
+        print("adopted %d: confidence min %.2f median %.2f, ≥0.60 %d / ≥0.55 %d / ≥0.40 %d" % (
+            len(ad), min(cs), statistics.median(cs), sum(c >= 0.6 for c in cs), sum(c >= 0.55 for c in cs), sum(c >= 0.4 for c in cs)))
+    if a.out:
+        n = rf.apply(G, ad, a.min_confidence)
+        if a.version:
+            G.graph["network_version"] = a.version
+        with open(a.out, "wb") as f:
+            pickle.dump(G, f)
+        print("applied %d derived links → %s (%d/%d)" % (n, a.out, G.number_of_nodes(), G.number_of_edges()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_edge_snap.py
+++ b/tests/test_edge_snap.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""링크 투영 스냅 (#67, v1.23.0).
+
+  1) 긴 링크 중간의 좌표는 링크 위 점(가상 노드)에 붙고, 경로가 링크 끝으로 되돌아가지 않는다
+  2) 안전 필터 — 보행 링크가 가까이 있으면 도로 링크 제외 / crossing·steps 는 투영 금지 / 건물을 가로지르는 투영 탈락
+  3) 링크 끝 1m 이내면 가상 노드 대신 끝 노드
+  4) API — 출발지가 링크 중간이면 첫 안내가 목적지 방향(우회비 ≈ 1), 실측 출입구 도착지는 노드 스냅 유지
+"""
+import json
+import os
+import sys
+
+import networkx as nx
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from route_service.engine import vsnap  # noqa: E402
+from route_service.engine.graph import NetworkStore  # noqa: E402
+from route_service.engine import profiles as prof  # noqa: E402
+
+WM = prof.PROFILES["wheelchair_manual"]
+
+
+def _edge(**kw):
+    d = dict(length=100.0, slope=1.0, link_type="sidewalk", width=2.0, curb_cut=True, surface="asphalt",
+             link_name=None, geometry=None)
+    d.update(kw)
+    return d
+
+
+def long_graph():
+    """A ──(sidewalk 200m, 동서)── B ──(sidewalk 100m, 북)── C(목적지)
+       A 의 서쪽 끝. 출발지는 A–B 의 3/4 지점 남쪽 5m — 노드 스냅이면 B(50m) 가 아니라 ... 아니, 노드 스냅은 B.
+       그러나 목적지가 A 쪽에 있는 경우를 만들기 위해 D 를 A 북쪽에 둔다."""
+    G = nx.Graph()
+    G.add_node("A", lat=37.3900, lon=126.9500, node_type="intersection")
+    G.add_node("B", lat=37.3900, lon=126.9523, node_type="intersection")   # 약 203m 동쪽
+    G.add_node("D", lat=37.3909, lon=126.9500, node_type="entrance")       # A 북쪽 100m (목적지)
+    G.add_edge("A", "B", **_edge(length=203.0))
+    G.add_edge("A", "D", **_edge(length=100.0))
+    return G
+
+
+def _store(G):
+    s = NetworkStore()
+    s.load_graph_object(G, version="t", region="t")
+    return s
+
+
+def test_projects_to_link_and_route_does_not_backtrack():
+    st = _store(long_graph())
+    # 출발지: A–B 링크의 3/4 지점(B 에서 50m) 남쪽 4m
+    lat, lng = 37.3900 - 0.00004, 126.9500 + 0.0023 * 0.75
+    cands = vsnap.candidates(st, lat, lng, WM, WM.hard_slope(), allowed=set(st.graph.nodes))
+    assert cands and cands[0]["u"] in ("A", "B") and 0.7 < cands[0]["t"] < 0.8 or 0.2 < cands[0]["t"] < 0.3
+    assert cands[0]["dist_m"] < 6
+    H = vsnap.virtual_graph(st)
+    vid = vsnap.attach(H, cands[0], "V_o_0")
+    assert vid.startswith("V_") and H.nodes[vid]["virtual"]
+    assert st.graph.number_of_nodes() == 3, "공유 그래프는 그대로여야 한다"
+    # 가상 노드에서 D 까지: V→A→D = 152m + 100m. 노드 스냅(B)이면 B→A→D = 303m
+    from route_service.engine.planner import plan
+    r = plan(st, vid, "D", WM, 1, graph=H)
+    assert 240 < r["routes"][0]["summary"]["total_distance_m"] < 265
+
+
+def test_layered_snap_prefers_sidewalk_and_skips_crossing_steps():
+    G = long_graph()
+    # A–B 와 나란한 도로 링크(남쪽 6m)와 계단·횡단보도 링크를 더한다
+    G.add_node("R1", lat=37.38995, lon=126.9500); G.add_node("R2", lat=37.38995, lon=126.9523)
+    G.add_edge("R1", "R2", **_edge(link_type="road", length=203.0))
+    G.add_node("S1", lat=37.3901, lon=126.9510); G.add_node("S2", lat=37.3903, lon=126.9510)
+    G.add_edge("S1", "S2", **_edge(link_type="steps", length=22.0))
+    G.add_node("X1", lat=37.3899, lon=126.9512); G.add_node("X2", lat=37.3901, lon=126.9512)
+    G.add_edge("X1", "X2", **_edge(link_type="crossing", length=22.0))
+    st = _store(G)
+    lat, lng = 37.38997, 126.9511          # 도로(3m)가 보도(3m)만큼 가깝고 계단·횡단보도가 바로 옆
+    cands = vsnap.candidates(st, lat, lng, WM, WM.hard_slope(), allowed=set(G.nodes), k=5)
+    types = [c["link_type"] for c in cands]
+    assert "steps" not in types and "crossing" not in types
+    assert "road" not in types, "보행 링크가 20m 안에 있으면 도로 링크는 후보에서 빠진다"
+    assert types[0] == "sidewalk"
+    # 보행 링크가 없는 곳에서는 도로 링크에 붙는다
+    G2 = nx.Graph(); G2.add_node("R1", lat=37.38995, lon=126.9500); G2.add_node("R2", lat=37.38995, lon=126.9523)
+    G2.add_edge("R1", "R2", **_edge(link_type="road", length=203.0))
+    st2 = _store(G2)
+    assert vsnap.candidates(st2, lat, lng, WM, WM.hard_slope(), allowed=set(G2.nodes))[0]["link_type"] == "road"
+
+
+def test_line_of_sight_blocks_projection_through_building():
+    from shapely.geometry import Polygon
+    G = long_graph(); st = _store(G)
+
+    class B:
+        loaded = True
+        polys = [(Polygon([(126.9508, 37.38985), (126.9514, 37.38985), (126.9514, 37.38999), (126.9508, 37.38999)]), "건물")]
+    los = vsnap.LineOfSight(buildings=B())
+    lat, lng = 37.3898, 126.9511            # 건물 남쪽 — 보도(북쪽)까지 선분이 건물을 가로지른다
+    assert los.blocked(lat, lng, 37.3900, 126.9511)
+    assert vsnap.candidates(st, lat, lng, WM, WM.hard_slope(), allowed=set(G.nodes), los=los) == []
+    # 건물 안 좌표(대표점)는 경계를 한 번 나가는 것이라 허용
+    assert not los.blocked(37.3899, 126.9511, 37.3900, 126.9511)
+
+
+def test_attach_near_link_end_returns_end_node():
+    st = _store(long_graph()); H = vsnap.virtual_graph(st)
+    c = vsnap.candidates(st, 37.3900, 126.95001, WM, WM.hard_slope(), allowed=set(st.graph.nodes))[0]
+    assert vsnap.attach(H, c, "V_x") == "A"
+    assert H.number_of_nodes() == 3
+
+
+# ── API ──
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    import pickle
+    net = tmp_path / "network.gpickle"
+    with open(net, "wb") as f:
+        pickle.dump(long_graph(), f)
+    poi_dir = tmp_path / "poi"; poi_dir.mkdir()
+    (poi_dir / "tour_bf.json").write_text(json.dumps([{
+        "poi_id": "TBF-D", "name": "목적지", "addr": "안양", "latitude": 37.3909, "longitude": 126.9500,
+        "entrance": {"lat": 37.3909, "lng": 126.9500},
+    }], ensure_ascii=False), encoding="utf-8")
+    (poi_dir / "entrances.json").write_text(json.dumps(
+        {"TBF-D": {"lat": 37.3909, "lng": 126.9500, "note": "정문"}}), encoding="utf-8")
+    monkeypatch.setenv("NETWORK_PATH", str(net)); monkeypatch.setenv("NETWORK_VERSION", "test-1")
+    monkeypatch.setenv("POI_BACKEND", "file"); monkeypatch.setenv("POI_DATA_DIR", str(poi_dir))
+    monkeypatch.setenv("ENTRANCES_PATH", str(poi_dir / "entrances.json"))
+    monkeypatch.setenv("ROUTE_API_TOKEN", "")
+    import importlib
+    import route_service.config as cfg
+    importlib.reload(cfg); cfg._settings = None
+    import route_service.api.main as m
+    importlib.reload(m)
+    with TestClient(m.app) as c:
+        yield c
+
+
+def test_api_origin_mid_link_heads_toward_destination(client):
+    body = {"origin": {"lat": 37.3900 - 0.00004, "lng": 126.9500 + 0.0023 * 0.75},
+            "destination": {"type": "coord", "lat": 37.3909, "lng": 126.9500}, "profile": "wheelchair_manual"}
+    r = client.post("/route/plan", json=body); assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["origin"]["snap_kind"] == "edge" and d["origin"]["snap_dist_m"] < 6
+    dist = d["routes"][0]["summary"]["total_distance_m"]
+    assert dist < 270, "링크 중간 출발이 B 까지 갔다 되돌아오면 300m 를 넘는다: %s" % dist
+    first = d["routes"][0]["steps"][0]
+    assert first["maneuver"] == "depart" and first["distance_m"] < 160
+    # 도착지(coord)도 링크 투영 — 노드 D 에 0m 이므로 노드 자체
+    assert d["destination"]["snap_dist_m"] < 1
+
+
+def test_api_entrance_destination_keeps_node_snap(client):
+    body = {"origin": {"lat": 37.3900 - 0.00004, "lng": 126.9500 + 0.0023 * 0.75},
+            "destination": {"type": "tour", "poi_id": "TBF-D"}, "profile": "wheelchair_manual"}
+    r = client.post("/route/plan", json=body); assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["destination"]["resolved_by"] == "manual_survey"
+    assert d["destination"]["snap_kind"] == "node"
+
+
+def test_api_edge_snap_can_be_disabled(client, monkeypatch):
+    import route_service.api.main as m
+    monkeypatch.setattr(m.settings, "edge_snap", False)
+    body = {"origin": {"lat": 37.3900 - 0.00004, "lng": 126.9500 + 0.0023 * 0.75},
+            "destination": {"type": "coord", "lat": 37.3909, "lng": 126.9500}, "profile": "wheelchair_manual"}
+    d = client.post("/route/plan", json=body).json()
+    assert d["origin"]["snap_kind"] == "node"
+    assert d["routes"][0]["summary"]["total_distance_m"] > 290

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""우회 삼각형 직결 링크 정제 (#67, v1.23.0) — 합성 그래프·폴리곤으로 게이트·신뢰도·반영·라우팅 활성 하한을 검증한다."""
+import math
+import os
+import sys
+
+import networkx as nx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from route_service.topomap import refine as rf  # noqa: E402
+from route_service.topomap.obstacles import ObstacleIndex  # noqa: E402
+from route_service.engine.graph import NetworkStore  # noqa: E402
+from route_service.engine.planner import plan, edge_passable, edge_cost  # noqa: E402
+from route_service.engine import profiles as prof  # noqa: E402
+
+shapely = pytest.importorskip("shapely")
+from shapely.geometry import Polygon, LineString, Point  # noqa: E402
+
+LAT, LON = 37.3900, 126.9500
+KX, KY = 111_320.0 * math.cos(math.radians(LAT)), 110_540.0
+
+
+def _pt(dx, dy):
+    """원점에서 동쪽 dx m, 북쪽 dy m 인 (lat, lon)."""
+    return (LAT + dy / KY, LON + dx / KX)
+
+
+def _poly(x0, y0, x1, y1):
+    return Polygon([(LON + x0 / KX, LAT + y0 / KY), (LON + x1 / KX, LAT + y0 / KY),
+                    (LON + x1 / KX, LAT + y1 / KY), (LON + x0 / KX, LAT + y1 / KY)])
+
+
+def _edge(a, b, **kw):
+    d = dict(slope=1.0, link_type="sidewalk", width=2.0, curb_cut=True, surface="블록", link_name=None, geometry=None)
+    d.update(kw)
+    return d
+
+
+def triangle_graph(mid_type="sidewalk"):
+    """A(0,0) ─ M(6,8) ─ B(12,0): 우회 20m, 직선 12m (우회비 1.67). D 는 A 서쪽 30m 의 직진 이웃."""
+    G = nx.Graph()
+    for n, (dx, dy) in {"A": (0, 0), "M": (6, 8), "B": (12, 0), "D": (-30, 0), "E": (42, 0)}.items():
+        la, lo = _pt(dx, dy)
+        G.add_node(n, lat=la, lon=lo, node_type="intersection")
+    G.add_edge("A", "M", length=10.0, **_edge("A", "M", link_type=mid_type))
+    G.add_edge("M", "B", length=10.0, **_edge("M", "B", link_type=mid_type))
+    G.add_edge("D", "A", length=30.0, **_edge("D", "A"))
+    G.add_edge("B", "E", length=30.0, **_edge("B", "E"))
+    return G
+
+
+def test_find_candidates_detour_triangle():
+    G = triangle_graph()
+    c = rf.find_candidates(G)
+    assert len(c) == 1 and {c[0]["a"], c[0]["b"]} == {"A", "B"} and c[0]["m"] == "M"
+    assert 11.5 < c[0]["straight_m"] < 12.5 and abs(c[0]["ratio"] - 20 / c[0]["straight_m"]) < 0.01
+
+
+def test_hard_gate_sidewalk_coverage_and_crossing():
+    G = triangle_graph()
+    c = rf.find_candidates(G)[0]
+    inside = rf.SidewalkIndex([{"geom": _poly(-40, -2, 50, 10), "width": 2.5}])
+    assert rf.hard_gate(G, c, inside, None) is None
+    outside = rf.SidewalkIndex([{"geom": _poly(-40, 3, 50, 10), "width": 2.5}])   # 직결선(y=0)이 폴리곤 밖
+    assert rf.hard_gate(G, c, outside, None).startswith("H1")
+    # 우회 구간이 횡단보도면 H11
+    G2 = triangle_graph(mid_type="crossing")
+    assert rf.hard_gate(G2, rf.find_candidates(G2)[0], inside, None).startswith("H11")
+
+
+def test_hard_gate_obstacles_block():
+    G = triangle_graph(); c = rf.find_candidates(G)[0]
+    sw = rf.SidewalkIndex([{"geom": _poly(-40, -2, 50, 10), "width": 2.5}])
+    wall = LineString([(LON + 6 / KX, LAT - 3 / KY), (LON + 6 / KX, LAT + 3 / KY)])   # 직결선을 가로지르는 옹벽
+    ob = ObstacleIndex([{"obstacle": "wall", "geom": wall}])
+    assert "옹벽" in rf.hard_gate(G, c, sw, ob)
+    # 볼라드 두 개 간격 0.5m 가 선분 위 — 통과 간격 부족
+    ob2 = ObstacleIndex([{"obstacle": "street_furniture", "geom": Point(LON + 6 / KX, LAT + 0.3 / KY)},
+                         {"obstacle": "street_furniture", "geom": Point(LON + 6 / KX, LAT - 0.2 / KY)}])
+    assert rf.hard_gate(G, c, sw, ob2) is not None
+
+
+def test_confidence_inset_fragmentation_touch_exemption():
+    G = triangle_graph(); c = rf.find_candidates(G)[0]
+    wide = rf.SidewalkIndex([{"geom": _poly(-40, -2, 50, 10), "width": 2.5}])
+    assert rf.confidence(G, c, wide)[0] == 1.0
+    # 폴리곤 경계가 선분에 0.1m — 인셋(0.2m) 밖 → ×0.55
+    edge = rf.SidewalkIndex([{"geom": _poly(-40, -0.1, 50, 10), "width": 2.5}])
+    v, why = rf.confidence(G, c, edge)
+    assert v == pytest.approx(0.55) and any("인셋" in w for w in why)
+    # 도엽 경계에서 맞닿은 두 폴리곤(간격 0) — 파편화 감점 없음
+    touching = rf.SidewalkIndex([{"geom": _poly(-40, -2, 6, 10), "width": 2.5}, {"geom": _poly(6, -2, 50, 10), "width": 2.5}])
+    assert rf.confidence(G, c, touching)[0] == 1.0
+    # 0.5m 벌어진 두 폴리곤 — 파편화 ×0.60 (H1 은 0.3m 까지만 흡수하므로 게이트도 걸린다)
+    gap = rf.SidewalkIndex([{"geom": _poly(-40, -2, 5.7, 10), "width": 2.5}, {"geom": _poly(6.2, -2, 50, 10), "width": 2.5}])
+    assert rf.hard_gate(G, c, gap, None).startswith("H1")
+    # 폭 1.2m 보도 → ×0.70
+    narrow = rf.SidewalkIndex([{"geom": _poly(-40, -2, 50, 10), "width": 1.2}])
+    assert rf.confidence(G, c, narrow)[0] == pytest.approx(0.70)
+
+
+def test_apply_adds_derived_link_and_profiles_gate_by_confidence():
+    G = triangle_graph(); c = rf.find_candidates(G)[0]
+    c["confidence"], c["penalties"] = 0.58, []
+    assert rf.apply(G, [c]) == 1 and G.has_edge("A", "B")
+    d = G["A"]["B"]
+    assert d["topo_source"] == "derived" and d["confidence"] == 0.58 and d["link_type"] == "sidewalk"
+    assert G.has_edge("A", "M") and G.has_edge("M", "B"), "기존 링크는 지우지 않는다"
+    wm, we, walk = prof.PROFILES["wheelchair_manual"], prof.PROFILES["wheelchair_electric"], prof.PROFILES["walk"]
+    assert not edge_passable(d, wm, wm.hard_slope()), "수동 휠체어 하한 0.60 미만"
+    assert edge_passable(d, we, we.hard_slope()) and edge_passable(d, walk, walk.hard_slope())
+    # 비용: length × (1 + 4(1−c))
+    assert edge_cost(d, walk) == pytest.approx(d["length"] * (1 + 4 * 0.42), rel=1e-3)   # DEM 없이 slope 0
+    st = NetworkStore(); st.load_graph_object(G, version="t", region="t")
+    assert plan(st, "D", "E", wm, 1)["routes"][0]["path"] == ["D", "A", "M", "B", "E"]
+    # 도보 프로필은 통행 가능하지만 c=0.58 이면 비용 2.7배라 우회로가 여전히 싸다 — 증거가 쌓여야 이긴다
+    assert plan(st, "D", "E", walk, 1)["routes"][0]["path"] == ["D", "A", "M", "B", "E"]
+    # 신뢰도가 높으면 수동 휠체어도 지름길
+    d["confidence"] = 0.9
+    st2 = NetworkStore(); st2.load_graph_object(G, version="t", region="t")
+    assert plan(st2, "D", "E", wm, 1)["routes"][0]["path"] == ["D", "A", "B", "E"]
+    assert plan(st2, "D", "E", walk, 1)["routes"][0]["path"] == ["D", "A", "B", "E"]
+
+
+def test_refine_pipeline_end_to_end():
+    G = triangle_graph()
+    sw = rf.SidewalkIndex([{"geom": _poly(-40, -2, 50, 10), "width": 2.5}])
+    res = rf.refine(G, sw, ObstacleIndex([]))
+    assert res["reasons"]["adopted"] == 1 and res["adopted"][0]["confidence"] == 1.0
+    assert rf.apply(G, res["adopted"], 0.6) == 1

--- a/tests/test_transit_plan.py
+++ b/tests/test_transit_plan.py
@@ -179,8 +179,10 @@ def test_walk_bus_legs_contract(client):
     assert body["mode"] == "walk_bus"
     legs = body["routes"][0]["legs"]
     kinds = [l["kind"] for l in legs]
-    assert kinds == ["bus", "walk"], kinds     # 첫 도보는 지척이라 생략
-    bus = legs[0]
+    # v1.23.0 링크 투영 스냅: 승차 정류장(18m 앞, 링크 중간)까지의 짧은 도보 leg 가 생긴다
+    assert kinds == ["walk", "bus", "walk"], kinds
+    assert legs[0]["summary"]["total_distance_m"] < 25
+    bus = legs[1]
     assert bus["route"]["route_id"] == "R100" and bus["route"]["type"] == "마을버스"
     assert bus["board"]["station_seq"] == 5 and bus["alight"]["station_seq"] == 9
     assert bus["stop_cnt"] == 4 and len(bus["stops"]) == 5


### PR DESCRIPTION
Closes #67

## 변경
### A. 링크 투영 스냅 (`engine/vsnap.py`)
- 출발·도착 좌표를 최근접 링크 위의 점에 요청 단위 가상 노드로 붙인다(공유 그래프 무수정). 반경 60m 상위 3개 링크 + 노드 스냅 폴백에서 "투영 거리 + 경로 비용" 최소 조합을 택한다.
- 안전 필터: 20m 안에 보행 링크가 있으면 도로 링크 제외 · `crossing`·`steps`·`overpass`·`underpass` 투영 금지 · 좌표→투영점 선분이 건물(또는 옹벽·담장 색인)을 가로지르면 탈락 · 노드가 2m 이내면 노드, 노드보다 5m 넘게 먼 링크 후보는 버림(먼 접근점이 경사 가중으로 뽑혀 유턴이 생기던 회귀 방지).
- 실측 출입구(`manual_survey`·`accessible_entrance`) 도착점은 노드 스냅 유지. 응답 `origin/destination.snap_kind`. `EDGE_SNAP=false` 로 끌 수 있다.
### C. 우회 삼각형 직결 링크 정제 (`topomap/refine.py`, `scripts/refine_detour_links.py`, `scripts/build_topomap_layers.py`)
- 하드 게이트: 인도 면형 밖(이음새 0.3m 흡수) · 계단·옹벽·담장·가로시설물 · 점형 지물 간격 0.8m · 종단경사 8° · 지그재그 경사로 · 우회 구간이 횡단보도 링크.
- 신뢰도: 내부 인셋 0.2m(양 끝 1m 제외) ×0.55 · 폭 1.5m 미만 ×0.70 · 비접촉 파편화 ×0.60 · 접합각 60° 미만 ×0.70. 고도차 감점은 두지 않는다(신설선 양 끝이 우회로와 같은 점이라 항상 같음).
- 라우팅: `topo_source='derived'` 링크는 프로필별 활성 하한(수동 0.60·전동 0.55·시각 0.70·도보 0.40) 미만이면 없는 링크, 통과분은 `length × (1 + 4(1 − c))`. 기존 링크는 지우지 않는다.
- 안양 실행: 후보 414 → 인도 면형 밖 237 · 횡단보도 우회 173 · 채택 4(c 1.0·1.0·0.7·0.55). 안양문화원 앞 직결 c=1.0. 그래프 `anyang-hybrid-2026Q3r1`(+4 링크).

## 테스트
- `tests/test_edge_snap.py` 7건(투영·계층·crossing/steps 제외·LOS·끝 노드·API 3건), `tests/test_refine.py` 6건(후보·게이트·장애물·인셋/파편화/폭·반영과 프로필 하한·파이프라인). 전체 `pytest -q`: 181 passed, compileall OK.
- 실그래프 회귀 9구간: 거리 불변 또는 단축 — 안양아트센터 → 안양문화원 1,283 → 1,060m(우회비 1.55 → 1.28, 첫 안내가 목적지 방향), 안양문화원 앞 10.6m 직결 사용(B·C·F 구간 −11m·스텝 감소), 계단 관통 링크 증가 0, 요청당 약 +40ms.
