### PR TITLE
v1.23.1 - 이면도로 횡단 교량 정제: 보도 노드 쌍 20m 이내·우회비 4 이상·이면도로 1개 횡단만 crossing(unmarked) 링크로 신설

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | 레포 | 버전 |
 |---|---|
-| 02-IITP-DABT-Route | v1.23.0 |
+| 02-IITP-DABT-Route | v1.23.1 |
 
 ## 구조
 
@@ -269,7 +269,7 @@ A–M, M–B 인접 링크는 있는데 A–B 직결이 없어 짧은 거리를 
 python scripts/build_topomap_layers.py --src "<1:1000 도엽 폴더>" --out data/topomap_layers          # 인도 면형·장애물 (한 번)
 python scripts/refine_detour_links.py --graph data/network_anyang_hybrid.gpickle --layers data/topomap_layers \
     --dem data/dem/anyang_5m.tif --report data/refine_report.csv \
-    --out data/network_anyang_hybrid_r1.gpickle --version anyang-hybrid-2026Q3r1
+    --out data/network_anyang_hybrid_r2.gpickle --version anyang-hybrid-2026Q3r2
 ```
 
 - 후보: 차수 무관, 우회비 ≥ 1.41·우회량 < 20m·직선 ≤ 25m.
@@ -278,6 +278,17 @@ python scripts/refine_detour_links.py --graph data/network_anyang_hybrid.gpickle
 - 반영: `topo_source='derived'`·`confidence=c` 로 **추가만** 한다(기존 링크·지그재그 경사로는 그대로). 라우팅은 프로필별 활성 하한(수동 0.60·전동 0.55·시각 0.70·도보 0.40) 미만이면 없는 링크로 보고, 통과분은 `length × (1 + 4(1 − c))` 비용으로 저울질한다.
 - 안양 실측(2026-09-07): 후보 414 → 인도 면형 밖 237(대부분 인도 없는 이면도로) · 횡단보도 우회 173 · **채택 4**(c 1.0·1.0·0.7·0.55). 안양문화원 앞 직결 링크 c=1.0 → 모든 프로필이 10.6m 직결로 지난다. 보고서 `data/refine_report.csv`.
 - 회귀(실증 구간 9건): 거리 불변 또는 단축(안양아트센터 → 안양문화원 1,283 → 1,060m), 계단 관통 링크 증가 0.
+
+#### 이면도로 횡단 교량 (v1.23.1)
+
+우회 삼각형과는 다른 결함. 좁은 이면도로 양쪽의 보도 끝이 십수 m 거리인데 횡단 링크가 없어 블록을 한 바퀴 돈다
+(안양문화원 → 소방서 정류장: 직선 61m 를 374m). 보도 면형 안이 아니므로 위 게이트로는 절대 통과하지 못해 별도 규칙을 둔다.
+같은 스크립트가 `<report>_gaps.csv` 를 함께 내고 `--out` 이면 같이 반영한다.
+
+- 후보: 양 끝이 수치지형도 보도 노드, 직선 3~20m, 둘 사이 보행망 경로가 없거나 직선의 4배 이상.
+- 게이트: 신설선이 도로 링크를 **정확히 하나**만 가로지르고 그 도로가 이면도로(이름이 없거나 `…길`, 간선 `…로`·`…대로`는 제외) · 장애물 저촉 없음 · 종단경사 8° 이하.
+- 반영: `link_type='crossing'`·`unmarked=True`·`confidence=0.65`. 수동(0.60)·전동·도보는 지나고 **시각장애(0.70)는 표시된 횡단보도만** 쓴다. 안내 문구는 "이면도로를 건너 17m 이동합니다. 횡단보도 표시가 없으니 차량을 살피세요." 로 나뉜다.
+- 안양 실측(2026-09-07): 후보 16 → 간선 횡단 8 제외 · **채택 8**(현충로52번길·현충로48번길·경수대로1192번길·문예로24번길·안양로111번길). 안양문화원 → 소방서 정류장 374 → 75m. 실증 구간 9건 회귀 불변. 그래프 `anyang-hybrid-2026Q3r2`.
 
 ### 저상버스 우선 모드 (v1.22.0)
 

--- a/route_service/__init__.py
+++ b/route_service/__init__.py
@@ -5,4 +5,4 @@ poi/     : 무장애 관광지 · 대중교통 접근점 조회
 api/     : FastAPI 래퍼 (12-AccessistantAI 등 클라이언트가 호출)
 """
 
-__version__ = "1.23.0"
+__version__ = "1.23.1"

--- a/route_service/engine/steps.py
+++ b/route_service/engine/steps.py
@@ -174,7 +174,11 @@ def _sentence(maneuver: str, distance_m: float, link_name, data: dict, warnings:
     if maneuver == "arrive":
         return "목적지에 도착했습니다."
     if lt == "crossing":
-        base = "횡단보도를 건너 %dm 이동합니다." % dist
+        if data.get("unmarked"):
+            # 정제로 이은 이면도로 횡단(#67) — 횡단보도 표시가 없다. 지시형 대신 주의 문구
+            base = "이면도로를 건너 %dm 이동합니다. 횡단보도 표시가 없으니 차량을 살피세요." % dist
+        else:
+            base = "횡단보도를 건너 %dm 이동합니다." % dist
     elif lt == "elevator":
         base = "승강기를 이용해 이동합니다."
     elif lt == "ramp":

--- a/route_service/topomap/refine.py
+++ b/route_service/topomap/refine.py
@@ -289,3 +289,134 @@ def apply(G, adopted: list, min_confidence: float = 0.0) -> int:
         G.add_edge(c["a"], c["b"], **data)
         n += 1
     return n
+
+
+# ────────────────────────── 이면도로 횡단 교량 (gap bridge) ──────────────────────────
+# 우회 삼각형과는 다른 결함: 좁은 이면도로 양쪽 보도 끝이 십수 m 거리인데 횡단 링크가 없어
+# 블록을 한 바퀴 돈다(안양문화원 → 소방서 정류장: 직선 61m 를 374m, 실측 2026-09-07).
+# 보도 폴리곤 안이 아니므로 우회 삼각형 게이트로는 절대 통과하지 못한다. 별도 규칙:
+#   · 양 끝이 수치지형도 보도 노드(topo1k 링크에 붙은 노드), 직선 ≤ GAP_MAX_M
+#   · 두 노드 사이 보행망 경로가 없거나 직선의 GAP_RATIO_MIN 배 이상
+#   · 신설선이 **도로 링크를 정확히 하나**만 가로지르고, 그 도로가 이면도로(이름이 없거나 '…길'로 끝남 — 간선은 '…로'·'…대로')
+#   · 장애물(옹벽·담장·계단·시설물) 저촉 없음, 종단경사 ≤ 8°
+# 반영: link_type='crossing', unmarked=True(안내 문구 분기), curb_cut=None(미확인 — 수동휠체어는 False 일 때만 막힌다),
+#       topo_source='derived', confidence=GAP_CONFIDENCE(0.65: 수동 0.60 활성·시각 0.70 비활성 — 시각장애 이용자는 표시된 횡단보도만).
+GAP_MAX_M = 20.0
+GAP_RATIO_MIN = 4.0
+GAP_CONFIDENCE = 0.65
+MINOR_ROAD_SUFFIX = ("길",)
+MAJOR_ROAD_SUFFIX = ("대로", "로")
+
+
+def _is_minor_road(name) -> bool:
+    n = (name or "").strip()
+    if not n:
+        return True
+    if n.endswith(MINOR_ROAD_SUFFIX):
+        return True
+    return False
+
+
+def _sidewalk_node(G, n) -> bool:
+    return any(G[n][x].get("topo_source") == "topo1k" and G[n][x].get("link_type") == "sidewalk" for x in G[n])
+
+
+def _road_links_crossed(G, pa, pb, cell_nodes):
+    """신설선이 가로지르는 도로 링크 목록 [(u, v, name)]."""
+    from shapely.geometry import LineString
+    seg = LineString([(pa[1], pa[0]), (pb[1], pb[0])])
+    out, seen = [], set()
+    for n in cell_nodes:
+        for x in G[n]:
+            key = frozenset((n, x))
+            if key in seen:
+                continue
+            seen.add(key)
+            d = G[n][x]
+            if d.get("link_type") not in ("road", "unknown"):
+                continue
+            from ..engine.graph import edge_coords
+            coords = edge_coords(G, n, x)
+            line = LineString([(c[1], c[0]) for c in coords])
+            if line.crosses(seg):
+                out.append((n, x, d.get("link_name")))
+    return out
+
+
+def find_gap_bridges(G, obstacles=None, dem=None) -> list:
+    """이면도로 횡단 교량 후보. 반환 항목은 우회 삼각형 후보와 같은 키 + gate/confidence."""
+    import networkx as nx
+    nodes = [n for n in G.nodes if _sidewalk_node(G, n)]
+    # 격자 색인(약 30m 셀)
+    grid = {}
+    def cell(lat, lon):
+        return (int(lat / 0.00027), int(lon / 0.00034))
+    for n in G.nodes:
+        grid.setdefault(cell(G.nodes[n]["lat"], G.nodes[n]["lon"]), []).append(n)
+    def around(lat, lon):
+        c = cell(lat, lon)
+        out = []
+        for di in (-1, 0, 1):
+            for dj in (-1, 0, 1):
+                out += grid.get((c[0] + di, c[1] + dj), [])
+        return out
+    out, seen = [], set()
+    for a in nodes:
+        pa = (G.nodes[a]["lat"], G.nodes[a]["lon"])
+        near = around(*pa)
+        for b in near:
+            if b == a or b in G[a] or not _sidewalk_node(G, b):
+                continue
+            key = (min(str(a), str(b)), max(str(a), str(b)))
+            if key in seen:
+                continue
+            seen.add(key)
+            pb = (G.nodes[b]["lat"], G.nodes[b]["lon"])
+            straight = haversine_m(pa[0], pa[1], pb[0], pb[1])
+            if straight < 3.0 or straight > GAP_MAX_M:
+                continue
+            crossed = _road_links_crossed(G, pa, pb, near)
+            if len(crossed) != 1:
+                continue
+            c = {"a": a, "m": None, "b": b, "pa": pa, "pb": pb, "pm": None, "straight_m": straight,
+                 "via_m": None, "ratio": None, "type_am": "sidewalk", "type_mb": "sidewalk",
+                 "kind": "gap_bridge", "road_name": crossed[0][2]}
+            # 기존 경로 길이 (없으면 무한)
+            try:
+                via = nx.shortest_path_length(G, a, b, weight="length")
+            except (nx.NetworkXNoPath, nx.NodeNotFound):
+                via = float("inf")
+            c["via_m"], c["ratio"] = (None if via == float("inf") else via), (None if via == float("inf") else via / straight)
+            if via != float("inf") and via / straight < GAP_RATIO_MIN:
+                continue
+            if not _is_minor_road(crossed[0][2]):
+                c["gate"] = "G1 간선 횡단(%s)" % crossed[0][2]
+                out.append(c); continue
+            if obstacles is not None:
+                from shapely.geometry import LineString
+                why = obstacles.blocks_new_link(LineString([(pa[1], pa[0]), (pb[1], pb[0])]))
+                if why:
+                    c["gate"] = "G3 " + why; out.append(c); continue
+            za, zb = _node_elev(G, a, dem), _node_elev(G, b, dem)
+            if za is not None and zb is not None:
+                slope = math.degrees(math.atan2(abs(za - zb), max(straight, 0.1)))
+                c["slope_deg"] = round(slope, 2)
+                if slope > HARD_SLOPE_DEG:
+                    c["gate"] = "G8 종단경사 %.1f도" % slope; out.append(c); continue
+            c["gate"] = None
+            c["confidence"], c["penalties"] = GAP_CONFIDENCE, ["이면도로 횡단(횡단보도 표시 없음)"]
+            out.append(c)
+    return out
+
+
+def apply_gap_bridges(G, cands: list) -> int:
+    n = 0
+    for c in cands:
+        if c.get("gate") or G.has_edge(c["a"], c["b"]):
+            continue
+        G.add_edge(c["a"], c["b"], length=float(c["straight_m"]), slope=float(c.get("slope_deg") or 0.0),
+                   link_type="crossing", width=None, curb_cut=None, surface=None, link_name=c.get("road_name"),
+                   geometry=None, tactile_paving=None, topo_source="derived", confidence=float(c["confidence"]),
+                   unmarked=True, derived_kind="gap_bridge")
+        n += 1
+    return n

--- a/scripts/refine_detour_links.py
+++ b/scripts/refine_detour_links.py
@@ -3,7 +3,7 @@
 
     python scripts/refine_detour_links.py --graph data/network_anyang_hybrid.gpickle \\
         --layers data/topomap_layers --dem data/dem/anyang_5m.tif \\
-        --out data/network_anyang_hybrid_r1.gpickle --report data/refine_report.csv --version anyang-hybrid-2026Q3r1
+        --out data/network_anyang_hybrid_r2.gpickle --report data/refine_report.csv --version anyang-hybrid-2026Q3r2
 
 --layers 는 scripts/build_topomap_layers.py 산출(sidewalk_polys.geojson, obstacles.geojson).
 --out 을 주지 않으면 보고서만 낸다. 활성 하한은 런타임 프로필이 판단하므로 채택분은 전부 넣는다(--min-confidence 로 제한 가능).
@@ -55,6 +55,16 @@ def main():
             w.writerow([c["a"], c["m"], c["b"], "%.7f" % c["pa"][0], "%.7f" % c["pa"][1], "%.7f" % c["pb"][0], "%.7f" % c["pb"][1],
                         "%.1f" % c["straight_m"], "%.1f" % c["via_m"], "%.2f" % c["ratio"], c["type_am"], c["type_mb"],
                         c.get("gate") or "", c.get("confidence", ""), "|".join(c.get("penalties", [])), c.get("slope_deg", "")])
+    gaps = rf.find_gap_bridges(G, ob, dem)
+    from collections import Counter
+    print("gap bridges %d → %s" % (len(gaps), dict(Counter((c.get("gate") or "adopted").split(" ")[0] for c in gaps))), flush=True)
+    with open(a.report.replace(".csv", "_gaps.csv"), "w", newline="", encoding="utf-8") as fp:
+        w = csv.writer(fp)
+        w.writerow(["a", "b", "lat_a", "lon_a", "lat_b", "lon_b", "straight_m", "via_m", "ratio", "road_name", "gate", "confidence", "slope_deg"])
+        for c in gaps:
+            w.writerow([c["a"], c["b"], "%.7f" % c["pa"][0], "%.7f" % c["pa"][1], "%.7f" % c["pb"][0], "%.7f" % c["pb"][1],
+                        "%.1f" % c["straight_m"], "" if c["via_m"] is None else "%.1f" % c["via_m"], "" if c["ratio"] is None else "%.2f" % c["ratio"],
+                        c.get("road_name") or "", c.get("gate") or "", c.get("confidence", ""), c.get("slope_deg", "")])
     ad = res["adopted"]
     if ad:
         import statistics
@@ -63,6 +73,7 @@ def main():
             len(ad), min(cs), statistics.median(cs), sum(c >= 0.6 for c in cs), sum(c >= 0.55 for c in cs), sum(c >= 0.4 for c in cs)))
     if a.out:
         n = rf.apply(G, ad, a.min_confidence)
+        n += rf.apply_gap_bridges(G, gaps)
         if a.version:
             G.graph["network_version"] = a.version
         with open(a.out, "wb") as f:

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -130,3 +130,61 @@ def test_refine_pipeline_end_to_end():
     res = rf.refine(G, sw, ObstacleIndex([]))
     assert res["reasons"]["adopted"] == 1 and res["adopted"][0]["confidence"] == 1.0
     assert rf.apply(G, res["adopted"], 0.6) == 1
+
+
+# ---- 이면도로 횡단 교량 (gap bridge) ----
+
+def gap_graph(road_name="현충로52번길", ratio_ok=True):
+    """A(0,0)·B(12,0) 는 보도 노드, 사이를 남북 도로(R1–R2, x=6)가 가른다.
+    A·B 는 도로를 따라가는 먼 우회로(A–P–Q–B, 총 200m)로만 연결된다."""
+    G = nx.Graph()
+    pts = {"A": (0, 0), "B": (12, 0), "A0": (-20, 0), "B0": (32, 0), "R1": (6, -40), "R2": (6, 40),
+           "P": (0, 100), "Q": (12, 100)}
+    for n, (dx, dy) in pts.items():
+        la, lo = _pt(dx, dy)
+        G.add_node(n, lat=la, lon=lo, node_type="intersection")
+    G.add_edge("A0", "A", length=20.0, topo_source="topo1k", **_edge("A0", "A"))
+    G.add_edge("B", "B0", length=20.0, topo_source="topo1k", **_edge("B", "B0"))
+    G.add_edge("R1", "R2", length=80.0, **_edge("R1", "R2", link_type="road", link_name=road_name))
+    via = 100.0 if ratio_ok else 12.0
+    G.add_edge("A", "P", length=via / 2 if not ratio_ok else 100.0, **_edge("A", "P"))
+    G.add_edge("P", "Q", length=12.0 if ratio_ok else 1.0, **_edge("P", "Q"))
+    G.add_edge("Q", "B", length=100.0 if ratio_ok else 5.0, **_edge("Q", "B"))
+    return G
+
+
+def test_gap_bridge_minor_road_adopted():
+    G = gap_graph()
+    c = rf.find_gap_bridges(G)
+    hit = [x for x in c if {x["a"], x["b"]} == {"A", "B"}]
+    assert len(hit) == 1 and hit[0]["gate"] is None and hit[0]["road_name"] == "현충로52번길"
+    assert hit[0]["confidence"] == rf.GAP_CONFIDENCE and hit[0]["ratio"] > rf.GAP_RATIO_MIN
+    n = rf.apply_gap_bridges(G, c)
+    assert n == 1 and G.has_edge("A", "B")
+    d = G["A"]["B"]
+    assert d["link_type"] == "crossing" and d["unmarked"] is True and d["topo_source"] == "derived"
+    # 수동 휠체어(하한 0.60)는 통과, 시각장애(0.70)는 불가
+    wm, vi = prof.PROFILES["wheelchair_manual"], prof.PROFILES["visual"]
+    assert edge_passable(d, wm, wm.hard_slope())
+    assert not edge_passable(d, vi, vi.hard_slope())
+
+
+def test_gap_bridge_major_road_gated():
+    G = gap_graph(road_name="소곡로")
+    c = [x for x in rf.find_gap_bridges(G) if {x["a"], x["b"]} == {"A", "B"}]
+    assert len(c) == 1 and c[0]["gate"].startswith("G1")
+    assert rf.apply_gap_bridges(G, c) == 0 and not G.has_edge("A", "B")
+
+
+def test_gap_bridge_short_detour_skipped():
+    G = gap_graph(ratio_ok=False)
+    c = [x for x in rf.find_gap_bridges(G) if {x["a"], x["b"]} == {"A", "B"}]
+    assert c == []
+
+
+def test_unmarked_crossing_sentence():
+    from route_service.engine.steps import _sentence
+    s = _sentence("straight", 17.2, "현충로52번길", {"link_type": "crossing", "unmarked": True}, [])
+    assert "이면도로를 건너" in s and "횡단보도 표시가 없으니" in s
+    s2 = _sentence("straight", 17.2, None, {"link_type": "crossing"}, [])
+    assert "이면도로" not in s2


### PR DESCRIPTION
#67 후속. v1.23.0 배포 후 안양문화원 → 김중업건축박물관 `walk_bus` 에서 출발지 도보 구간(안양문화원 → 소방서 정류장)이 직선 61m 를 374m 로 도는 문제가 남아 있었다. 원인은 우회 삼각형이 아니라 **좁은 이면도로(현충로52번길) 양쪽 보도 끝 사이에 횡단 링크가 없어** 블록을 한 바퀴 도는 결함이다. 보도 면형 밖이라 v1.23.0 게이트로는 절대 통과하지 못하므로 별도 규칙을 둔다.

## 변경
### 이면도로 횡단 교량 (`topomap/refine.py` `find_gap_bridges`/`apply_gap_bridges`)
- 후보: 양 끝이 수치지형도 보도 노드, 직선 3~20m, 둘 사이 보행망 경로가 없거나 직선의 4배 이상.
- 게이트: 신설선이 도로 링크를 **정확히 하나**만 가로지르고 그 도로가 이면도로(이름이 없거나 `…길`; `…로`·`…대로` 간선은 G1 제외) · 장애물(옹벽·담장·계단·시설물) 저촉 없음(G3) · 종단경사 8° 이하(G8).
- 반영: `link_type='crossing'`·`unmarked=True`·`topo_source='derived'`·`confidence=0.65`. 프로필별 활성 하한에 따라 수동(0.60)·전동·도보는 지나고 **시각장애(0.70)는 표시된 횡단보도만** 쓴다. 기존 링크는 지우지 않는다.
- `scripts/refine_detour_links.py`: `<report>_gaps.csv` 를 함께 내고 `--out` 이면 같이 반영.
- `engine/steps.py`: `unmarked` 횡단은 "이면도로를 건너 17m 이동합니다. 횡단보도 표시가 없으니 차량을 살피세요." 로 문구 분기.

## 안양 실행
- 교량 후보 16 → 간선 횡단(소곡로·예술공원로·냉천로·안양천서로·전파로) 8 제외 · **채택 8**(현충로52번길 2·현충로48번길·경수대로1192번길 2·문예로24번길 2·안양로111번길). 그래프 `anyang-hybrid-2026Q3r2`(v1.23.0 직결 4 + 교량 8 = 10,171 링크).
- 안양문화원 → 소방서 정류장: 수동·전동·도보 **374 → 75m**(직선 61m), 시각장애는 종전 경로 유지. 실증 구간 9건 회귀: 거리·스텝·급회전 전부 불변.

## 테스트
- `tests/test_refine.py` +4(이면도로 채택과 프로필 하한·간선 G1 차단·짧은 우회 제외·문구). 전체 `pytest -q`: 185 passed.